### PR TITLE
Hotfix: 리버스 프록시 context 에 맞춘 oauth 인증 경로 변경 작업

### DIFF
--- a/src/main/java/org/oreo/smore/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/oreo/smore/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -2,15 +2,16 @@ package org.oreo.smore.domain.auth.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -23,18 +24,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws IOException, ServletException {
-        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (header != null && header.startsWith("Bearer ")) {
-            String token = header.substring(7);
+        // 1) 쿠키에서 accessToken 추출
+        String token = extractTokenFromCookies(request);
 
-            if (tokenProvider.validateToken(token, true)) {
-                String userId = tokenProvider.getUserIdFromToken(token, true);
-                JwtAuthenticationToken auth =
-                        new JwtAuthenticationToken(userId, AuthorityUtils.NO_AUTHORITIES);
-                SecurityContextHolder.getContext().setAuthentication(auth);
-            }
+        // 2) 검증 및 SecurityContext 설정
+        if (token != null && tokenProvider.validateToken(token, true)) {
+            String userId = tokenProvider.getUserIdFromToken(token, true);
+            JwtAuthenticationToken auth =
+                    new JwtAuthenticationToken(userId, AuthorityUtils.NO_AUTHORITIES);
+            SecurityContextHolder.getContext().setAuthentication(auth);
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private String extractTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies)
+                .filter(c -> "accessToken".equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/org/oreo/smore/global/config/SecurityConfig.java
+++ b/src/main/java/org/oreo/smore/global/config/SecurityConfig.java
@@ -8,10 +8,12 @@ import org.oreo.smore.domain.auth.token.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -26,11 +28,13 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http, TokenService tokenService) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v1/auth/**", "/oauth2/**").permitAll()
                         .anyRequest().authenticated()
                 )
-
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(u -> u.userService(oAuth2UserService))
                         .successHandler(new OAuth2SuccessHandler(tokenProvider, tokenService))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
             scope:
               - email
               - profile
-            redirect-uri: ${OAUTH2_REDIRECT_URI:{baseUrl}/login/oauth2/code/{registrationId}}
+            redirect-uri: ${OAUTH2_REDIRECT_URI:${baseUrl}/api/login/oauth2/code/{registrationId}}
             client-name: Google
 
 jwt:
@@ -44,7 +44,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate    # ?? ????? validate ?? none ??
+      ddl-auto: ${JPA_DDL_AUTO_SET}  # ?? ????? validate ?? none ??
     show-sql: false
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
@@ -64,7 +64,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate    # ?? ????? validate ?? none ??
+      ddl-auto: ${JPA_DDL_AUTO_SET}    # ?? ????? validate ?? none ??
     show-sql: false
     database-platform: org.hibernate.dialect.MySQL8Dialect
 


### PR DESCRIPTION
# Summary
OAuth2 리다이렉트 URI 설정을 환경 변수와 `{baseUrl}` 플레이스홀더로 개선하고, Nginx `/api` 프록시 경로를 반영하도록 수정했습니다.

# Changes
- **Feat:** Spring Security OAuth2 클라이언트 설정에 `redirect-uri` 환경 변수·플레이스홀더 적용  
- **Chore:** Nginx 프록시 경로(`/api`)에 맞춘 리다이렉트 경로 구성
- 기본 로그인 페이지로 redirect 되는 spring security 동작 수정
- jwt 인증 필터 인증방식 헤더 -> 쿠키 방식으로 수정

# Details

### OAuth2 Redirect URI 설정
- **application.yaml** 에서 Google 클라이언트에 아래처럼 `redirect-uri`를 지정  
  ```yaml
  spring:
    security:
      oauth2:
        client:
          registration:
            google:
              redirect-uri: "${OAUTH2_REDIRECT_URI:${baseUrl}/api/login/oauth2/code/{registrationId}}"
OAUTH2_REDIRECT_URI 환경 변수를 우선 사용

없을 경우 https://{host}/api/login/oauth2/code/google 형태로 자동 대체