### PR TITLE
Hotfix: 정상 로그인 요청 시 401 반환 오류 수

### DIFF
--- a/src/main/java/org/oreo/smore/global/config/SecurityConfig.java
+++ b/src/main/java/org/oreo/smore/global/config/SecurityConfig.java
@@ -32,7 +32,11 @@ public class SecurityConfig {
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v1/auth/**", "/oauth2/**").permitAll()
+                        .requestMatchers(
+                                "/v1/auth/**",
+                                "/oauth2/**",   // 로그인 시작 엔드포인트
+                                "/login/oauth2/code/**"  // 콜백 엔드포인트
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
# Summary
1. 정상 로그인 요청 시, 콜백 엔드포인트 permit 열기

# Changes
- security filter chain 내부 authorizeHttpRequests 부분 수정

# Details

### 1. OAuth2 Redirect URI 설정  
security filter chain 내부 permit 열기 `/login/oauth2/code/**`  // 콜백 엔드포인트