### PR TITLE
Hotfix: Nginx 처리에 맞게 oauth 경로 수정

### DIFF
--- a/src/main/java/org/oreo/smore/domain/auth/AuthController.java
+++ b/src/main/java/org/oreo/smore/domain/auth/AuthController.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/v1/auth")
+@RequestMapping("/api/v1/auth")
 @CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 @RequiredArgsConstructor
 public class AuthController {

--- a/src/main/java/org/oreo/smore/global/config/SecurityConfig.java
+++ b/src/main/java/org/oreo/smore/global/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService oAuth2UserService;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, TokenService tokenService) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .exceptionHandling(ex -> ex
@@ -33,13 +33,19 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/v1/auth/**",
-                                "/oauth2/**",   // 로그인 시작 엔드포인트
-                                "/login/oauth2/code/**"  // 콜백 엔드포인트
+                                "/api/v1/auth/**",                  // 자체 로그인/회원가입 API
+                                "/api/oauth2/authorization/**",     // OAuth2 로그인 진입점
+                                "/api/login/oauth2/code/**"         // OAuth2 콜백 엔드포인트
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authz -> authz
+                                .baseUri("/api/oauth2/authorization")
+                        )
+                        .redirectionEndpoint(redir -> redir
+                                .baseUri("/api/login/oauth2/code/*")
+                        )
                         .userInfoEndpoint(u -> u.userService(oAuth2UserService))
                         .successHandler(new OAuth2SuccessHandler(tokenProvider, tokenService))
                 )


### PR DESCRIPTION
# Summary
1. 정상 로그인 요청 시, 콜백 엔드포인트 permit 열기
2. 기본 oauth 엔드 포인트 및 콜백 엔드포인트 수정
3. authController 부분 수정

# Changes
- 기본 oauth 엔드 포인트 및 콜백 엔드포인트 수정

# Details
Nginx에서 
```
location /api {
        proxy_pass http://host.docker.internal:8081/api;
    }
```
로 요청을 도커 8081 안으로 넣어주면서 /api를 다시 붙여줌.

spring 내부에서는 그냥 /api 넣어서 모든 요청 처리하면 됨.