### PR TITLE
Hotfix: servlet context에 /api 추가

### DIFF
--- a/src/main/java/org/oreo/smore/domain/auth/AuthController.java
+++ b/src/main/java/org/oreo/smore/domain/auth/AuthController.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/v1/auth")
 @CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 @RequiredArgsConstructor
 public class AuthController {

--- a/src/main/java/org/oreo/smore/global/config/SecurityConfig.java
+++ b/src/main/java/org/oreo/smore/global/config/SecurityConfig.java
@@ -33,18 +33,18 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/v1/auth/**",                  // 자체 로그인/회원가입 API
-                                "/api/oauth2/authorization/**",     // OAuth2 로그인 진입점
-                                "/api/login/oauth2/code/**"         // OAuth2 콜백 엔드포인트
+                                "/v1/auth/**",                  // 자체 로그인/회원가입 API
+                                "/oauth2/authorization/**",     // OAuth2 로그인 진입점
+                                "/login/oauth2/code/**"         // OAuth2 콜백 엔드포인트
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authz -> authz
-                                .baseUri("/api/oauth2/authorization")
+                                .baseUri("/oauth2/authorization")
                         )
                         .redirectionEndpoint(redir -> redir
-                                .baseUri("/api/login/oauth2/code/*")
+                                .baseUri("/login/oauth2/code/*")
                         )
                         .userInfoEndpoint(u -> u.userService(oAuth2UserService))
                         .successHandler(new OAuth2SuccessHandler(tokenProvider, tokenService))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 server:
   port: ${PORT:8081}
-
+  servlet:
+    context-path: /api
 spring:
   application:
     name: smore
@@ -20,7 +21,7 @@ spring:
             scope:
               - email
               - profile
-            redirect-uri: ${OAUTH2_REDIRECT_URI:${baseUrl}/api/login/oauth2/code/{registrationId}}
+            redirect-uri: ${OAUTH2_REDIRECT_URI:${baseUrl}/login/oauth2/code/{registrationId}}
             client-name: Google
 
 jwt:


### PR DESCRIPTION
# Summary
1. Spring context path에 `/api` 추가

# Changes
- 기본 oauth 엔드 포인트 및 콜백 엔드포인트 다시 수정 `/api` 를 뻄
```
server:
  servlet:
    context-path: /api
```
# Details
spring 내부에서 /api 를 context path로 추가