### PR TITLE
fix: application.yml 파일에서 DB URL 세부 분리

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,7 @@ spring:
       on-profile: dev
 
   datasource:
-    url: ${DEV_DB_URL}
+    url: jdbc:mysql://${DEV_DB_HOST}:${DEV_DB_PORT}/${DEV_DB_NAME}?${DEV_DB_PARAMS}
     username: ${DEV_DB_USERNAME}
     password: ${DEV_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -58,7 +58,7 @@ spring:
       on-profile: prod
 
   datasource:
-    url: ${PROD_DB_URL}
+    url: jdbc:mysql://${PROD_DB_HOST}:${PROD_DB_PORT}/${PROD_DB_NAME}?${PROD_DB_PARAMS}
     username: ${PROD_DB_USERNAME}
     password: ${PROD_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
기존: DB_URL에 host, port, db name, param 이 모두 담겨있었음
수정: 이를 세부적으로 분리 - ai 서버에서도 같은 .env 사용하기 위함