### PR TITLE
Feat: user information retrieve

### DIFF
--- a/src/main/java/org/oreo/smore/domain/user/UserController.java
+++ b/src/main/java/org/oreo/smore/domain/user/UserController.java
@@ -3,6 +3,7 @@ package org.oreo.smore.domain.user;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.oreo.smore.domain.user.dto.request.UserUpdateRequest;
+import org.oreo.smore.domain.user.dto.response.UserInfoResponse;
 import org.oreo.smore.domain.user.dto.response.UserUpdateResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -46,4 +47,17 @@ public class UserController {
 
         return ResponseEntity.ok(userService.updateUser(userId, userUpdateRequest));
     }
+
+    @GetMapping("/v1/users/{userId}")
+    public ResponseEntity<UserInfoResponse> getUserInfo(
+            @PathVariable Long userId,
+            Authentication authentication) {
+
+        if (Long.parseLong(authentication.getPrincipal().toString()) != userId) {
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED); // userId가 다르면 401
+        }
+
+        return ResponseEntity.ok(userService.getUserInfo(userId));
+    }
+
 }

--- a/src/main/java/org/oreo/smore/domain/user/UserController.java
+++ b/src/main/java/org/oreo/smore/domain/user/UserController.java
@@ -3,7 +3,7 @@ package org.oreo.smore.domain.user;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.oreo.smore.domain.user.dto.request.UserUpdateRequest;
-import org.oreo.smore.domain.user.dto.request.UserUpdateResponse;
+import org.oreo.smore.domain.user.dto.response.UserUpdateResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/oreo/smore/domain/user/UserRepository.java
+++ b/src/main/java/org/oreo/smore/domain/user/UserRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/oreo/smore/domain/user/UserService.java
+++ b/src/main/java/org/oreo/smore/domain/user/UserService.java
@@ -2,6 +2,7 @@ package org.oreo.smore.domain.user;
 
 import lombok.RequiredArgsConstructor;
 import org.oreo.smore.domain.user.dto.request.UserUpdateRequest;
+import org.oreo.smore.domain.user.dto.response.UserInfoResponse;
 import org.oreo.smore.domain.user.dto.response.UserUpdateResponse;
 import org.oreo.smore.global.common.CloudStorageManager;
 import org.springframework.http.HttpStatus;
@@ -118,4 +119,7 @@ public class UserService {
     }
 
 
+    public UserInfoResponse getUserInfo(Long userId) {
+        return null;
+    }
 }

--- a/src/main/java/org/oreo/smore/domain/user/UserService.java
+++ b/src/main/java/org/oreo/smore/domain/user/UserService.java
@@ -2,7 +2,7 @@ package org.oreo.smore.domain.user;
 
 import lombok.RequiredArgsConstructor;
 import org.oreo.smore.domain.user.dto.request.UserUpdateRequest;
-import org.oreo.smore.domain.user.dto.request.UserUpdateResponse;
+import org.oreo.smore.domain.user.dto.response.UserUpdateResponse;
 import org.oreo.smore.global.common.CloudStorageManager;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -91,6 +91,11 @@ public class UserService {
         // 목표 공부 시간
         if (req.getGoalStudyTime() != null) {
             user.setGoalStudyTime(req.getGoalStudyTime());
+        }
+
+        // 각오
+        if (req.getDetermination() != null) {
+            user.setDetermination(req.getDetermination());
         }
 
         User saved = repository.save(user);

--- a/src/main/java/org/oreo/smore/domain/user/UserService.java
+++ b/src/main/java/org/oreo/smore/domain/user/UserService.java
@@ -4,8 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.oreo.smore.domain.user.dto.request.UserUpdateRequest;
 import org.oreo.smore.domain.user.dto.request.UserUpdateResponse;
 import org.oreo.smore.global.common.CloudStorageManager;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -48,6 +50,9 @@ public class UserService {
 
         // 닉네임 변경
         if (req.getNickname() != null && !req.getNickname().isBlank()) {
+            if (repository.existsByNickname(req.getNickname())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다.");
+            }
             user.setNickname(req.getNickname());
         }
 

--- a/src/main/java/org/oreo/smore/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/org/oreo/smore/domain/user/dto/request/UserUpdateRequest.java
@@ -30,4 +30,7 @@ public class UserUpdateRequest {
     @Min(value = 0, message = "목표 공부시간은 0 이상이어야 합니다.")
     @Max(value = 24, message = "목표 공부시간은 24 이하이어야 합니다.")
     private Integer goalStudyTime;
+
+    @Size(max = 50, message = "각오는 최대 50자까지 가능합니다.")
+    private String determination;
 }

--- a/src/main/java/org/oreo/smore/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/oreo/smore/domain/user/dto/response/UserInfoResponse.java
@@ -1,0 +1,4 @@
+package org.oreo.smore.domain.user.dto.response;
+
+public class UserInfoResponse {
+}

--- a/src/main/java/org/oreo/smore/domain/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/oreo/smore/domain/user/dto/response/UserInfoResponse.java
@@ -1,4 +1,33 @@
 package org.oreo.smore.domain.user.dto.response;
 
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class UserInfoResponse {
+
+    private DataResponse data;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DataResponse {
+        private Long userId;
+        private String name;
+        private String email;
+        private String nickname;
+        private String profileUrl;
+        private String createdAt;
+        private Integer goalStudyTime;
+        private String level;
+        private String targetDateTitle;
+        private String targetDate;
+        private String determination;
+        private Integer todayStudyMinute;
+    }
 }

--- a/src/main/java/org/oreo/smore/domain/user/dto/response/UserUpdateResponse.java
+++ b/src/main/java/org/oreo/smore/domain/user/dto/response/UserUpdateResponse.java
@@ -1,4 +1,4 @@
-package org.oreo.smore.domain.user.dto.request;
+package org.oreo.smore.domain.user.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/org/oreo/smore/global/common/CloudStorageManager.java
+++ b/src/main/java/org/oreo/smore/global/common/CloudStorageManager.java
@@ -33,7 +33,8 @@ public class CloudStorageManager {
             blobClient.setHttpHeaders(headers);
         }
 
-        return blobClient.getBlobUrl();
+        // 캐시 무효화를 위해 타임스탬프 쿼리 파라미터 추가
+        return blobClient.getBlobUrl() + "?t=" + System.currentTimeMillis();
     }
 
     /**
@@ -64,7 +65,8 @@ public class CloudStorageManager {
             blobClient.setHttpHeaders(headers);
         }
 
-        return blobClient.getBlobUrl();
+        // 캐시 무효화를 위해 타임스탬프 쿼리 파라미터 추가
+        return blobClient.getBlobUrl() + "?t=" + System.currentTimeMillis();
     }
 
     public void deleteRoomImage(Long roomId) {


### PR DESCRIPTION
# Summary
유저 정보 조회를 구현했습니다.

# Changes
feat: 이미지 url 캐시 무효화 로직 구현
fix: 닉네임 중복 안되게 오류 해결
fix: 각오 추가
feat: 유저 정보 조회 Controller 구현


feat: 유저 정보 조회 구현

# Details
자기 정보 수정에서 각오가 누락된 에러 수정