### PR TITLE
Fix: Auth 부분 로직 수정

### DIFF
--- a/src/main/java/org/oreo/smore/domain/auth/AuthController.java
+++ b/src/main/java/org/oreo/smore/domain/auth/AuthController.java
@@ -1,5 +1,6 @@
 package org.oreo.smore.domain.auth;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
@@ -12,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
 
 @RestController
 @RequestMapping("/v1/auth")
@@ -55,7 +58,11 @@ public class AuthController {
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        // ... refreshToken 삭제 로직 생략 ...
+        // 기존 refreshToken 삭제
+        String refresh = extractTokenFromCookies(request);
+        if(refresh != null) {
+            tokenService.deleteRefreshToken(refresh);
+        }
 
         // 쿠키 만료
         response.addHeader(HttpHeaders.SET_COOKIE,
@@ -87,5 +94,15 @@ public class AuthController {
     @AllArgsConstructor
     static class DataResponse<T> {
         private T data;
+    }
+
+    private String extractTokenFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        return Arrays.stream(cookies)
+                .filter(c -> "refreshToken".equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/org/oreo/smore/domain/auth/AuthController.java
+++ b/src/main/java/org/oreo/smore/domain/auth/AuthController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/auth")
-@CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/org/oreo/smore/domain/auth/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/org/oreo/smore/domain/auth/oauth/OAuth2SuccessHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.oreo.smore.domain.auth.jwt.JwtTokenProvider;
 import org.oreo.smore.domain.auth.token.TokenService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
@@ -18,6 +19,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtProvider;
     private final TokenService tokenService;
+
+    @Value("${app.oauth2.frontend.success-redirect-url}")
+    private String successRedirectUrl;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
@@ -51,9 +55,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        // TODO : 프론트 url 확정 시, 수정 필요(redirect URL)
         String redirectUrl = String.format(
-                "http://localhost:3000/studyList?userId=%s",
+                successRedirectUrl + "/study-list?userId=%s",
                 providerId
         );
         response.sendRedirect(redirectUrl);

--- a/src/main/java/org/oreo/smore/domain/user/UserService.java
+++ b/src/main/java/org/oreo/smore/domain/user/UserService.java
@@ -14,6 +14,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -32,12 +33,15 @@ public class UserService {
         User u = User.builder()
                 .name(name)
                 .email(email)
-                .nickname(name + "@" + email)
+                .nickname(UUID.randomUUID().toString())
                 .createdAt(LocalDateTime.now())
                 .goalStudyTime(0)
                 .level("O")
                 .build();
-        return repository.save(u);
+
+        User savedUser = repository.save(u);
+        savedUser.setNickname("OREO" + savedUser.getUserId());
+        return repository.save(savedUser);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/oreo/smore/global/config/CorsConfig.java
+++ b/src/main/java/org/oreo/smore/global/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package org.oreo.smore.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")             // 모든 엔드포인트에 대해
+                        .allowedOriginPatterns("*")              // 모든 origin 허용
+                        .allowedMethods("*")                     // 모든 HTTP 메서드 허용
+                        .allowedHeaders("*")                     // 모든 요청 헤더 허용
+                        .exposedHeaders("Authorization")         // 필요시 노출할 응답 헤더
+                        .allowCredentials(true)                  // 쿠키·자격증명 허용
+                        .maxAge(3600);                           // pre-flight 캐시 유효기간 (초)
+            }
+        };
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,11 @@ spring:
             redirect-uri: ${OAUTH2_REDIRECT_URI:${baseUrl}/login/oauth2/code/{registrationId}}
             client-name: Google
 
+app:
+  oauth2:
+    frontend:
+      success-redirect-url: ${FRONTEND_OAUTH2_SUCCESS_REDIRECT_URL:http://localhost:3000}
+
 jwt:
   access-token-secret: ${ACCESS_TOKEN_SECRET_KEY}
   refresh-token-secret: ${REFRESH_TOKEN_SECRET_KEY}


### PR DESCRIPTION
## Summary
OAuth2 리다이렉트 URL을 환경변수로 분리하고, 전역 CORS 정책을 적용했습니다. 회원가입 시 임시 UUID 대신 저장된 userId를 이용해 기본 닉네임을 설정하도록 변경했으며, 로그아웃 시 리프레시 토큰 삭제 로직을 추가했습니다.

## Changes
- Fix: OAuth2 리다이렉트 URL 환경변수 분리
- Fix: 전역 CORS 허용 설정 추가
- Fix: userId 이용 기본 닉네임 설정
- Feat: 로그아웃 시 리프레시 토큰 삭제 로직 추가

## Details
- Redirect URL 분리
- OAuth2SuccessHandler에서 하드코딩된 "http://localhost:3000/study-list" URL을 application.yml 및 환경변수(FRONTEND_STUDY_LIST_URL)로 관리하도록 변경
- @Value("${app.oauth2.frontend.study-list-url}") 를 통해 주입

### 전역 CORS 설정
CorsConfig 클래스(WebMvcConfigurer 구현)에 addCorsMappings("/**") 를 사용해 모든 엔드포인트에 대해

allowedOriginPatterns("*")

allowCredentials(true)

allowedHeaders("*")

exposedHeaders("Authorization")

allowedMethods("*")

maxAge(3600)
설정을 추가

### 기본 닉네임 로직 개선
회원가입 메서드에서 첫 저장 시 임시 UUID를 넣지 않고, 저장된 userId를 기반으로 "OREO"+userId 형식의 닉네임을 한 번만 설정하도록 리팩토링

saveAndFlush() 이후 setNickname("OREO" + saved.getUserId()) 만 수행하여 DB 호출 최소화

### 로그아웃 시 토큰 삭제
/v1/auth/logout 엔드포인트에 리프레시 토큰을 서버 측에서 삭제하는 로직 추가

응답 쿠키로 refreshToken 및 accessToken 의 maxAge=0 설정을 통해 클라이언트 쿠키 만료 처리