### PR TITLE
Feat: 방 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/oreo/smore/domain/participant/Participant.java
+++ b/src/main/java/org/oreo/smore/domain/participant/Participant.java
@@ -1,4 +1,41 @@
 package org.oreo.smore.domain.participant;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "participants")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Participant {
+
+    @Id
+    @Column(name = "participant_id")
+    private Long participantId;
+
+    @Column(name = "room_id", nullable = false)
+    private Long roomId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "joined_at", nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "left_at")
+    private LocalDateTime leftAt;
+
+    @Column(name = "is_muted", nullable = false)
+    private Boolean isMuted;
+
+    @Column(name = "is_banned", nullable = false)
+    private Boolean isBanned;
 }

--- a/src/main/java/org/oreo/smore/domain/participant/ParticipantRepository.java
+++ b/src/main/java/org/oreo/smore/domain/participant/ParticipantRepository.java
@@ -1,4 +1,7 @@
 package org.oreo.smore.domain.participant;
 
-public class ParticipantRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    long countByRoomIdAndLeftAtIsNull(Long roomId);
 }

--- a/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomController.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.oreo.smore.domain.studyroom.dto.CreateStudyRoomRequest;
 import org.oreo.smore.domain.studyroom.dto.CreateStudyRoomResponse;
+import org.oreo.smore.domain.studyroom.dto.StudyRoomDto;
+import org.oreo.smore.global.common.CursorPage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class StudyRoomController {
 
     private final StudyRoomCreationService studyRoomCreationService;
+    private final StudyRoomService studyRoomService;
 
     @PostMapping
     public ResponseEntity<CreateStudyRoomResponse> createStudyRoom(
@@ -30,5 +33,18 @@ public class StudyRoomController {
                 response.getRoomId(), userId, response.getInviteHashCode());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<CursorPage<StudyRoomDto>> listStudyRooms(
+            @RequestParam(name="page", defaultValue="1") Long page,
+            @RequestParam(name="limit", defaultValue="20") int limit,
+            @RequestParam(name="search", required=false) String search,
+            @RequestParam(name="category", required=false) String category,
+            @RequestParam(name="sort", defaultValue="latest") String sort,
+            @RequestParam(name="hide-full-rooms", defaultValue="false") boolean hideFullRooms
+    ) {
+        CursorPage<StudyRoomDto> studyRoomDtoCursorPage = studyRoomService.listStudyRooms(page, limit, search, category, sort, hideFullRooms);
+        return ResponseEntity.ok(studyRoomDtoCursorPage);
     }
 }

--- a/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomRepository.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomRepository.java
@@ -1,5 +1,8 @@
 package org.oreo.smore.domain.studyroom;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -15,4 +18,7 @@ public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
 
     // 특정 카테고리 스터디룸을 최근 생성된 순으로 조회
     List<StudyRoom> findAllByCategoryAndDeletedAtIsNullOrderByCreatedAtDesc(StudyRoomCategory category);
+
+    // cursor 기반 페이징을 위한 메서드
+    Slice<StudyRoom> findAll(Specification<StudyRoom> spec, Pageable pageable);
 }

--- a/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomService.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomService.java
@@ -1,0 +1,129 @@
+package org.oreo.smore.domain.studyroom;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.RequiredArgsConstructor;
+import org.oreo.smore.domain.participant.ParticipantRepository;
+import org.oreo.smore.domain.studyroom.dto.StudyRoomDto;
+import org.oreo.smore.global.common.CursorPage;
+import org.oreo.smore.domain.user.User;
+import org.oreo.smore.domain.user.UserRepository;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomService {
+    private final StudyRoomRepository roomRepository;
+    private final ParticipantRepository participantRepository;
+    private final UserRepository userRepo;
+
+    public CursorPage<StudyRoomDto> listStudyRooms(
+            Long page,
+            int limit,
+            String search,
+            String category,
+            String sort,
+            boolean hideFullRooms
+    ) {
+        long cursor = (page != null && page > 1) ? page : Long.MAX_VALUE;;
+        Sort sortOrder = buildSortOrder(sort);
+        Pageable pageable = PageRequest.of(0, limit + 1, sortOrder);
+
+        List<StudyRoom> rooms = fetchRooms(cursor, search, category, pageable);
+        List<StudyRoomDto> dtos = mapAndFilterRooms(rooms, hideFullRooms);
+        if (isPopularSort(sort)) {
+            applyPopularSort(dtos);
+        }
+        return CursorPage.of(dtos, limit);
+    }
+
+    private Sort buildSortOrder(String sort) {
+        String property = isPopularSort(sort) ? "currentParticipants" : "createdAt";
+        return Sort.by(Sort.Direction.DESC, property);
+    }
+
+    private boolean isPopularSort(String sort) {
+        return "popular".equalsIgnoreCase(sort);
+    }
+
+    private List<StudyRoom> fetchRooms(
+            long cursor,
+            String search,
+            String category,
+            Pageable pageable
+    ) {
+        Specification<StudyRoom> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.isNull(root.get("deletedAt")));
+            predicates.add(cb.lessThan(root.get("roomId"), cursor));
+            addSearchPredicate(cb, root, predicates, search);
+            addCategoryPredicate(cb, root, predicates, category);
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return roomRepository.findAll(spec, pageable).getContent();
+    }
+
+    private void addSearchPredicate(
+            CriteriaBuilder cb,
+            Root<StudyRoom> root,
+            List<Predicate> preds,
+            String search
+    ) {
+        if (search != null && !search.isBlank()) {
+            preds.add(cb.like(
+                    cb.lower(root.get("title")),
+                    "%" + search.toLowerCase() + "%"
+            ));
+        }
+    }
+
+    private void addCategoryPredicate(
+            CriteriaBuilder cb,
+            Root<StudyRoom> root,
+            List<Predicate> preds,
+            String category
+    ) {
+        if (category != null && !category.isBlank()) {
+            try {
+                StudyRoomCategory catEnum = StudyRoomCategory.valueOf(category.toUpperCase());
+                preds.add(cb.equal(root.get("category"), catEnum));
+            } catch (IllegalArgumentException e) {
+                preds.add(cb.disjunction());
+            }
+        }
+    }
+
+    private List<StudyRoomDto> mapAndFilterRooms(
+            List<StudyRoom> rooms,
+            boolean hideFullRooms
+    ) {
+        return rooms.stream()
+                .map(this::toDto)
+                .filter(dto -> !hideFullRooms || dto.getCurrentParticipants() < dto.getMaxParticipants())
+                .collect(Collectors.toList());
+    }
+
+    private StudyRoomDto toDto(StudyRoom room) {
+        long count = participantRepository.countByRoomIdAndLeftAtIsNull(room.getRoomId());
+        User creator = userRepo.findById(room.getUserId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Creator not found: " + room.getUserId()
+                ));
+        return StudyRoomDto.of(room, count, creator.getNickname());
+    }
+
+    private void applyPopularSort(List<StudyRoomDto> dtos) {
+        dtos.sort(
+                Comparator.comparingLong(StudyRoomDto::getCurrentParticipants).reversed()
+        );
+    }
+}

--- a/src/main/java/org/oreo/smore/domain/studyroom/dto/StudyRoomDto.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/dto/StudyRoomDto.java
@@ -1,0 +1,80 @@
+// src/main/java/org/oreo/smore/domain/studyroom/dto/StudyRoomDto.java
+package org.oreo.smore.domain.studyroom.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.oreo.smore.global.common.CursorPage.Identifiable;
+import org.oreo.smore.domain.studyroom.StudyRoom;
+
+import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class StudyRoomDto implements Identifiable {
+    private Long roomId;
+
+    private String title;
+
+    private String thumbnailUrl;
+
+    private List<String> tag;
+
+    private String category;
+
+    private Integer maxParticipants;
+
+    private Long currentParticipants;
+
+    private String password;
+
+    private String createdAt;
+
+    private CreatorDto creator;
+
+    @Override
+    public Long getId() {
+        return roomId;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CreatorDto {
+        private String nickname;
+    }
+
+    /**
+     * 엔티티 + 집계값 → DTO
+     */
+    public static StudyRoomDto of(
+            StudyRoom e,
+            long       currentParticipants,
+            String     creatorNickname
+    ) {
+        List<String> tags = e.getTag() == null
+                ? Collections.emptyList()
+                : Arrays.asList(e.getTag().split(","));
+        String created = e.getCreatedAt()
+                .atOffset(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT);
+
+        return new StudyRoomDto(
+                e.getRoomId(),
+                e.getTitle(),
+                e.getThumbnailUrl(),
+                tags,
+                e.getCategory().name(),         // enum → String
+                e.getMaxParticipants(),
+                currentParticipants,
+                e.getPassword(),
+                created,
+                new CreatorDto(creatorNickname)
+        );
+    }
+}

--- a/src/main/java/org/oreo/smore/global/common/CursorPage.java
+++ b/src/main/java/org/oreo/smore/global/common/CursorPage.java
@@ -1,0 +1,40 @@
+package org.oreo.smore.global.common;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter @Setter @NoArgsConstructor
+public class CursorPage<T> {
+    private Long cursorId;
+    private int size;
+    private List<T> content;
+    private boolean hasNext;
+    private Long nextCursor;
+
+    public CursorPage(Long cursorId, int size) {
+        this.cursorId = cursorId;
+        this.size = size;
+    }
+
+    public static <T extends Identifiable> CursorPage<T> of(List<T> result, int size) {
+        boolean hasNext = result.size() > size;
+        List<T> pageContent = hasNext ? result.subList(0, size) : result;
+        Long nextCursor = pageContent.isEmpty() ? null : pageContent.get(pageContent.size() - 1).getId();
+        CursorPage<T> page = new CursorPage<>();
+        page.setContent(pageContent);
+        page.setHasNext(hasNext);
+        page.setNextCursor(nextCursor);
+        return page;
+    }
+
+    public Long getCursorIdOrDefault() {
+        return cursorId != null ? cursorId : Long.MAX_VALUE;
+    }
+
+    public interface Identifiable {
+        Long getId();
+    }
+}

--- a/src/test/java/org/oreo/smore/domain/studyroom/StudyRoomControllerTest.java
+++ b/src/test/java/org/oreo/smore/domain/studyroom/StudyRoomControllerTest.java
@@ -1,0 +1,140 @@
+package org.oreo.smore.domain.studyroom;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.oreo.smore.domain.studyroom.dto.StudyRoomDto;
+import org.oreo.smore.global.common.CursorPage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(StudyRoomController.class)
+class StudyRoomControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StudyRoomService studyRoomService;
+
+    @MockitoBean
+    private StudyRoomCreationService studyRoomCreationService;
+
+    @Test
+    @DisplayName("GET /v1/study-rooms 조회 시 빈 페이지 반환")
+    void listStudyRooms_ShouldReturnEmptyPage() throws Exception {
+        // given: Service가 빈 페이지를 반환하도록 Mock 설정
+        CursorPage<StudyRoomDto> emptyPage = new CursorPage<>();
+        emptyPage.setCursorId(1L);
+        emptyPage.setSize(20);
+        emptyPage.setContent(Collections.emptyList());
+        emptyPage.setHasNext(false);
+        emptyPage.setNextCursor(null);
+
+        given(studyRoomService.listStudyRooms(
+                anyLong(), anyInt(), any(), any(), anyString(), anyBoolean()
+        )).willReturn(emptyPage);
+
+        // when & then: 기본 파라미터로 조회 요청 시
+        mockMvc.perform(get("/v1/study-rooms")
+                        .param("page", "1")
+                        .param("limit", "20")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                // 페이징 메타데이터 검증
+                .andExpect(jsonPath("$.cursorId").value(1))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                // content 배열이 비어있는지 검증
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content").isEmpty());
+    }
+
+    @Test
+    @DisplayName("GET /v1/study-rooms 조회 시 기본 정렬(latest) 검증")
+    void listStudyRooms_WithSortParam() throws Exception {
+        // given: 하나의 더미 DTO 반환
+        StudyRoomDto dto = StudyRoomDto.builder()
+                .roomId(100L)
+                .title("테스트 스터디룸")
+                .build();
+
+        CursorPage<StudyRoomDto> page = new CursorPage<>();
+        page.setCursorId(100L);
+        page.setSize(1);
+        page.setContent(Collections.singletonList(dto));
+        page.setHasNext(false);
+        page.setNextCursor(null);
+
+        given(studyRoomService.listStudyRooms(
+                eq(5L), eq(1), isNull(), isNull(), eq("latest"), eq(true)
+        )).willReturn(page);
+
+        // when & then: 추가 파라미터를 포함하여 조회 요청
+        mockMvc.perform(get("/v1/study-rooms")
+                        .param("page", "5")
+                        .param("limit", "1")
+                        .param("hide-full-rooms", "true")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cursorId").value(100))
+                .andExpect(jsonPath("$.size").value(1))
+                .andExpect(jsonPath("$.content[0].roomId").value(100))
+                .andExpect(jsonPath("$.content[0].title").value("테스트 스터디룸"));
+    }
+
+    @Test
+    @DisplayName("GET /v1/study-rooms 여러 파라미터로 조회 시 서비스 호출 및 응답 검증")
+    void listStudyRooms_WithAllParams() throws Exception {
+        // given
+        StudyRoomDto dto = StudyRoomDto.builder()
+                .roomId(200L)
+                .title("여러 파람 테스트")
+                .build();
+        CursorPage<StudyRoomDto> page = new CursorPage<>();
+        page.setCursorId(200L);
+        page.setSize(1);
+        page.setContent(Collections.singletonList(dto));
+        page.setHasNext(false);
+        page.setNextCursor(null);
+
+        // service가 정확한 파라미터로 호출되도록 목 설정
+        given(studyRoomService.listStudyRooms(
+                eq(2L),           // page=2
+                eq(3),            // limit=3
+                eq("hello"),      // search=hello
+                eq("LANGUAGE"),   // category=LANGUAGE
+                eq("popular"),    // sort=popular
+                eq(false)         // hide_full_rooms=false
+        )).willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/v1/study-rooms")
+                        .param("page", "2")
+                        .param("limit", "3")
+                        .param("search", "hello")
+                        .param("category", "LANGUAGE")
+                        .param("sort", "popular")
+                        .param("hide-full-rooms", "false")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.cursorId").value(200))
+                .andExpect(jsonPath("$.size").value(1))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andExpect(jsonPath("$.content[0].roomId").value(200))
+                .andExpect(jsonPath("$.content[0].title").value("여러 파람 테스트"));
+    }
+}

--- a/src/test/java/org/oreo/smore/domain/studyroom/StudyRoomServiceTest.java
+++ b/src/test/java/org/oreo/smore/domain/studyroom/StudyRoomServiceTest.java
@@ -1,0 +1,108 @@
+package org.oreo.smore.domain.studyroom;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.oreo.smore.domain.participant.ParticipantRepository;
+import org.oreo.smore.domain.studyroom.dto.StudyRoomDto;
+import org.oreo.smore.domain.user.User;
+import org.oreo.smore.domain.user.UserRepository;
+import org.oreo.smore.global.common.CursorPage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class StudyRoomServiceTest {
+
+    @Mock
+    private StudyRoomRepository roomRepository;
+
+    @Mock
+    private ParticipantRepository participantRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private StudyRoomService studyRoomService;
+
+    @Test
+    @DisplayName("스터디룸이 없으면 빈 페이지 반환")
+    void listStudyRooms_NoRooms_ReturnsEmptyPage() {
+        // given
+        int limit = 10;
+        Pageable pageable = PageRequest.of(0, limit + 1, Sort.by(Sort.Direction.DESC, "createdAt"));
+        // repository에서 빈 Slice 반환
+        given(roomRepository.findAll(any(Specification.class), eq(pageable)))
+                .willReturn(new SliceImpl<>(Collections.emptyList(), pageable, false));
+
+        // when
+        CursorPage<StudyRoomDto> result =
+                studyRoomService.listStudyRooms(null, limit, null, null, null, false);
+
+        // then
+        assertNotNull(result);
+        assertTrue(result.getContent().isEmpty(), "content가 비어 있어야 합니다");
+        assertFalse(result.isHasNext(), "hasNext는 false여야 합니다");
+        assertNull(result.getNextCursor(), "nextCursor는 null이어야 합니다");
+    }
+
+    @Test
+    @DisplayName("단일 스터디룸 매핑 및 페이징 처리 검증")
+    void listStudyRooms_SingleRoom_MappedCorrectly() {
+        // given
+        int limit = 1;
+        StudyRoom room = mock(StudyRoom.class);
+
+        given(room.getRoomId()).willReturn(100L);
+        given(room.getUserId()).willReturn(42L);
+        given(room.getMaxParticipants()).willReturn(5);
+
+        // createdAt, title 등 기존 모킹…
+        LocalDateTime now = LocalDateTime.of(2025, 8, 7, 10, 0);
+        given(room.getCreatedAt()).willReturn(now);
+        given(room.getTitle()).willReturn("테스트 스터디룸");
+
+        // **category 모킹 추가**
+        given(room.getCategory()).willReturn(StudyRoomCategory.EMPLOYMENT);
+
+        Pageable pageable = PageRequest.of(0, limit + 1, Sort.by(Sort.Direction.DESC, "createdAt"));
+        given(roomRepository.findAll(any(Specification.class), eq(pageable)))
+                .willReturn(new SliceImpl<>(List.of(room), pageable, false));
+
+        given(participantRepository.countByRoomIdAndLeftAtIsNull(100L)).willReturn(3L);
+        User creator = new User();
+        creator.setNickname("tester");
+        given(userRepository.findById(42L)).willReturn(Optional.of(creator));
+
+        // when
+        CursorPage<StudyRoomDto> result =
+                studyRoomService.listStudyRooms(null, limit, "검색어", "EMPLOYMENT", "latest", true);
+
+        // then: DTO 필드들도 category 기반 로직에 맞춰 검증 가능
+        assertEquals(1, result.getContent().size());
+        StudyRoomDto dto = result.getContent().get(0);
+        assertEquals(100L, dto.getRoomId());
+        assertEquals("tester", dto.getCreator().getNickname());
+        assertEquals(3, dto.getCurrentParticipants());
+        assertEquals("EMPLOYMENT", dto.getCategory());  // enum.name() 값
+        assertFalse(result.isHasNext());
+        assertEquals(100L, result.getNextCursor());
+    }
+}


### PR DESCRIPTION
## Summary
스터디룸 전체 조회 API를 구현하고, 관련 기능에 대한 단위 및 통합 테스트 코드를 작성했습니다.

## Changes
Feat: /v1/study-rooms 전체 조회 엔드포인트 추가

Feat: cursor 기반 페이징·검색·카테고리·정렬·숨김 옵션을 지원하는 StudyRoomService#listStudyRooms 구현

Feat: Participant 엔티티 및 ParticipantRepository 추가/수정

Feat: StudyRoomDto 및 공통 페이징 유틸 CursorPage 정의

Test: StudyRoomControllerTest를 통한 컨트롤러 레이어 통합 테스트 작성

Test: StudyRoomServiceTest를 통한 서비스 레이어 단위 테스트 작성

## Details
### Participant 엔티티·Repository
participants 테이블 매핑을 위해 Participant 엔티티에 participantId, roomId, userId, joinedAt, leftAt, isMuted, isBanned 필드 추가

ParticipantRepository extends JpaRepository<Participant, Long> 에서 countByRoomIdAndLeftAtIsNull(Long roomId) 메서드로 현재 입장 중인 참가자 수 집계 지원

### Controller (StudyRoomController)
@GetMapping으로 /v1/study-rooms 엔드포인트 추가

### 요청 파라미터:

page(cursor, 기본값:1)

limit(페이지 크기, 기본값:20)

search(제목 키워드)

category(스터디룸 카테고리)

sort(latest 또는 popular)

hide-full-rooms(정원 채운 방 숨김 여부)

StudyRoomService 호출 후 CursorPage<StudyRoomDto> 를 반환

### Service (StudyRoomService)
Cursor 페이징: page 값이 없거나 1일 경우 Long.MAX_VALUE 커서 사용, 그 외는 전달된 page 값 그대로

정렬:

latest → createdAt DESC

popular → currentParticipants DESC (추가 정렬 로직으로 DTO 리스트 재정렬)

검색·카테고리 필터: JPA Specification 사용해 title LIKE, category = … 조건 추가

집계 및 매핑:

participantRepository.countByRoomIdAndLeftAtIsNull(...) 로 현재 참여자 수 계산

userRepository.findById(...) 로 생성자 닉네임 조회

StudyRoomDto.of(...) 로 엔티티 → DTO 변환

CursorPage.of(...) 호출로 결과 사이즈 제한 및 nextCursor, hasNext 설정

### DTO 및 페이징 유틸
StudyRoomDto

roomId, title, thumbnailUrl, tag 리스트, category, maxParticipants, currentParticipants, password, createdAt(ISO_INSTANT), creator 정보 포함

CursorPage<T>

cursorId, size, content, hasNext, nextCursor 필드로 구성

of(List<T>, size) 메서드로 커서 페이지 계산

### 테스트 코드
StudyRoomControllerTest

MockMvc + @WebMvcTest 환경에서 빈 결과, 기본 정렬, 모든 파라미터 케이스에 대한 HTTP 200 및 JSON 바디 검증

StudyRoomServiceTest

Mockito를 이용해 리포지토리 모킹

빈 데이터: 빈 Slice 반환 시 content 비어있음, hasNext=false, nextCursor=null 검증

단일 방 매핑: StudyRoom 모킹 객체로 roomId, userId, title, category, createdAt 등을 설정하고, 참여자 수·생성자 닉네임 모킹 후 DTO 필드(roomId, category, currentParticipants, creator.nickname, nextCursor) 검증