### PR TITLE
  Feat: 신규 기능 배포 

### DIFF
--- a/src/main/java/org/oreo/smore/domain/participant/Participant.java
+++ b/src/main/java/org/oreo/smore/domain/participant/Participant.java
@@ -1,23 +1,25 @@
 package org.oreo.smore.domain.participant;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.*;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Entity
-@Table(name = "participants")
+@Table(name= "participants")
 @Getter
-@Setter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Participant {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "participant_id")
     private Long participantId;
 
@@ -27,6 +29,7 @@ public class Participant {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
+    @CreatedDate
     @Column(name = "joined_at", nullable = false)
     private LocalDateTime joinedAt;
 
@@ -34,8 +37,67 @@ public class Participant {
     private LocalDateTime leftAt;
 
     @Column(name = "is_muted", nullable = false)
-    private Boolean isMuted;
+    private Boolean isMuted = false;
 
     @Column(name = "is_banned", nullable = false)
-    private Boolean isBanned;
+    private Boolean isBanned = false;
+
+    @Builder
+    public  Participant(Long roomId, Long userId) {
+        this.roomId = roomId;
+        this.userId = userId;
+        this.isMuted = false;
+        this.isBanned = false;
+
+        log.debug("새 참가자 객체 생성 - 방 ID: {}, 사용자ID: {}", roomId, userId);
+    }
+
+    // 음소거 설정
+    public void mute() {
+        this.isMuted = true;
+        log.info("참가자 음소거 설정 - 방ID: {}, 사용자ID: {}", roomId, userId);
+    }
+
+    // 음소거 해제
+    public void unmute() {
+        this.isMuted = false;
+        log.info("참가자 음소거 해제 - 방ID: {}, 사용자ID: {}", roomId, userId);
+    }
+
+    // 강퇴 처리
+    public void ban() {
+        this.isBanned = true;
+        this.leftAt = LocalDateTime.now();
+        log.warn("참가자 강퇴 처리 - 방ID: {}, 사용자ID: {}, 강퇴시간: {}",
+                roomId, userId, leftAt);
+    }
+
+    // 퇴장 처리
+    public void leave() {
+        this.leftAt = LocalDateTime.now();
+        log.info("참가자 퇴장 처리 - 방ID: {}, 사용자ID: {}, 퇴장시간: {}",
+                roomId, userId, leftAt);
+    }
+
+    // 현재 방에 있는지 확인
+    public boolean isInRoom() {
+        boolean inRoom = leftAt == null && !isBanned;
+        log.debug("참가자 방 존재 여부 확인 - 방ID: {}, 사용자ID: {}, 방 안에 있음: {}",
+                roomId, userId, inRoom);
+        return inRoom;
+    }
+
+    // 강퇴 당했는지 확인
+    public boolean isBannedFromRoom() {
+        log.debug("참가자 강퇴 상태 확인 - 방ID: {}, 사용자ID: {}, 강퇴됨: {}",
+                roomId, userId, isBanned);
+        return isBanned;
+    }
+
+    // 음소거 상태인지 확인
+    public boolean isMutedInRoom() {
+        log.debug("참가자 음소거 상태 확인 - 방ID: {}, 사용자ID: {}, 음소거됨: {}",
+                roomId, userId, isMuted);
+        return isMuted;
+    }
 }

--- a/src/main/java/org/oreo/smore/domain/participant/ParticipantRepository.java
+++ b/src/main/java/org/oreo/smore/domain/participant/ParticipantRepository.java
@@ -1,7 +1,42 @@
 package org.oreo.smore.domain.participant;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
+@Repository
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+    // 특정 방의 모든 참가자 조회 (입장 시간 순)
+    List<Participant> findByRoomIdOrderByJoinedAtAsc(Long roomId);
+
+    @Query("SELECT p FROM Participant p WHERE p.roomId = :roomId AND p.userId = :userId AND p.leftAt IS NULL AND p.isBanned = false")
+    Optional<Participant> findActiveParticipant(@Param("roomId") Long roomId, @Param("userId") Long userId);
+
+    // 특정 방의 현재 참가자 조회
+    @Query("SELECT p FROM Participant p WHERE p.roomId = :roomId AND p.leftAt IS NULL AND p.isBanned = false")
+    List<Participant> findActiveParticipantsByRoomId(@Param("roomId") Long roomId);
+
+    // 특정 사용자가 참가한 모든 방 조회 (취근 참가 순)
+    List<Participant> findByUserIdOrderByJoinedAtDesc(Long userId);
+    
+    // 특정 방의 현재 참가자 수 조회
+    @Query("SELECT COUNT(p) FROM Participant p WHERE p.roomId = :roomId AND p.leftAt IS NULL AND p.isBanned = false")
+    long countActiveParticipantsByRoomId(@Param("roomId") Long roomId);
+    
+    // 특정 방의 음소거된 참가자 조회
+    @Query("SELECT p FROM Participant p WHERE p.roomId = :roomId AND p.leftAt IS NULL AND p.isBanned = false AND p.isMuted = true")
+    List<Participant> findMutedParticipantsByRoomId(@Param("roomId") Long roomId);
+
+    // 특정 방의 참가 이력 삭제 (방 삭제시 사용)
+    void deleteByRoomId(Long roomId);
+
+    // 특정 사용자의 특정 방 참가 이력 삭제
+    void deleteByRoomIdAndUserId(Long roomId, Long userId);
+
     long countByRoomIdAndLeftAtIsNull(Long roomId);
 }

--- a/src/main/java/org/oreo/smore/domain/participant/ParticipantService.java
+++ b/src/main/java/org/oreo/smore/domain/participant/ParticipantService.java
@@ -1,4 +1,175 @@
 package org.oreo.smore.domain.participant;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.oreo.smore.domain.participant.exception.ParticipantException;
+import org.oreo.smore.domain.studyroom.StudyRoom;
+import org.oreo.smore.domain.studyroom.StudyRoomRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class ParticipantService {
+
+    private final ParticipantRepository participantRepository;
+    private final StudyRoomRepository studyRoomRepository;
+
+    // 참가자 등록
+    @Transactional
+    public Participant joinRoom(Long roomId, Long userId) {
+        log.info("참가자 등록 시작 - 방ID: {}, 사용자ID: {} ", roomId, userId);
+
+        // 방 존재 여부 확인
+        StudyRoom studyRoom = validateStudyRoomExists(roomId);
+
+        // 이미 참가중인지 확인
+        validateNotAlreadyInRoom(roomId, userId);
+
+        // 방 최대 인원 확인
+        validateRoomCapacity(studyRoom);
+
+        // 참가자 엔티티 생성
+        Participant participant = Participant.builder()
+                .roomId(roomId)
+                .userId(userId)
+                .build();
+
+        Participant savedParticipant = participantRepository.save(participant);
+
+        long currentCount = participantRepository.countActiveParticipantsByRoomId(roomId);
+        log.info("✅ 참가자 등록 완료 - 방ID: {}, 사용자ID: {}, 현재 참가자 수: {}/{}",
+                roomId, userId, currentCount, studyRoom.getMaxParticipants());
+
+        return savedParticipant;
+    }
+
+    // 참가자 퇴장 처리
+    @Transactional
+    public void leaveRoom(Long roomId, Long userId) {
+        log.info("참가자 퇴장 시작 - 방ID: {}, 사용자ID: {} ", roomId, userId);
+
+        Participant participant = findActiveParticipant(roomId, userId);
+        participant.leave();
+
+        long remainingCount = participantRepository.countActiveParticipantsByRoomId(roomId);
+        log.info("✅ 참가자 퇴장 완료 - 방ID: {}, 사용자ID: {}, 남은 참가자 수: {}",
+                roomId, userId, remainingCount);
+    }
+
+    // 활성화된 참가자 조회
+    private Participant findActiveParticipant(Long roomId, Long userId) {
+        List<Participant> activeParticipants = participantRepository.findActiveParticipantsByRoomId(roomId);
+
+        return activeParticipants.stream()
+                .filter(p -> p.getUserId().equals(userId))
+                .findFirst()
+                .orElseThrow(() -> {
+                    log.error("활성 참가자를 찾을 수 없음 - 방ID: {}, 사용자ID: {}", roomId, userId);
+                    return new ParticipantException.ParticipantNotFoundException(
+                            String.format("방 %d에서 사용자 %d를 찾을 수 없습니다", roomId, userId));
+                });
+    }
+
+
+    // 방 최대 인원 검증
+    private void validateRoomCapacity(StudyRoom studyRoom) {
+        long currentCount = participantRepository.countActiveParticipantsByRoomId(studyRoom.getRoomId());
+
+        if (currentCount >= studyRoom.getMaxParticipants()) {
+            log.warn("방 정원 초과 - 방ID: {}, 현재: {}, 최대: {}",
+                    studyRoom.getRoomId(), currentCount, studyRoom.getMaxParticipants());
+            throw new ParticipantException.RoomFullException(
+                    String.format("방이 가득함 (%d/%d)", currentCount, studyRoom.getMaxParticipants()));
+        }
+
+    }
+
+    // 이미 참가중인지 검증
+    private void validateNotAlreadyInRoom(Long roomId, Long userId) {
+        if (isUserInRoom(roomId, userId)) {
+            log.warn("이미 참가중인 사용자 - 방ID: {}, 사용자ID: {}", roomId, userId);
+            throw new ParticipantException.AlreadyJoinedException(
+                    String.format("사용자 %d는 이미 방 %d에 참가중입니다", userId, roomId));
+        }
+    }
+
+    // 사용자가 특정 방에 참가중인지 확인
+    public boolean isUserInRoom(Long roomId, Long userId) {
+        List<Participant> activeParticipants = getActiveParticipants(roomId);
+        boolean isInRoom = activeParticipants.stream()
+                .anyMatch(p -> p.getUserId().equals(userId));
+
+        log.debug("사용자 방 참가 여부 - 방ID: {}, 사용자ID: {}, 참가중: {}", roomId, userId, isInRoom);
+        return isInRoom;
+    
+    }
+
+    private List<Participant> getActiveParticipants(Long roomId) {
+        log.debug("현재 활성 참가자 조회 - 방ID: {}", roomId);
+        List<Participant> activeParticipants = participantRepository.findActiveParticipantsByRoomId(roomId);
+        log.debug("활성 참가자 수: {} - 방ID: {}", activeParticipants.size(), roomId);
+        return activeParticipants;
+
+    }
+
+    // 스터디룸 존재 여부 검증
+    private StudyRoom validateStudyRoomExists(Long roomId) {
+        return studyRoomRepository.findById(roomId)
+                .orElseThrow(() -> {
+                    log.error("존재하지 않는 방 - 방ID: {}", roomId);
+                    return new ParticipantException.StudyRoomNotFoundException(
+                            String.format("방 %d를 찾을 수 없습니다", roomId));
+                });
+    }
+
+    // 참가자 음소거 설정
+    @Transactional
+    public void muteParticipant(Long roomId, Long userId) {
+        log.info("참가자 음소거 설정 - 방ID: {}, 사용자ID: {}", roomId, userId);
+
+        Participant participant = findActiveParticipant(roomId, userId);
+        participant.mute();
+
+        log.info("✅ 참가자 음소거 설정 완료 - 방ID: {}, 사용자ID: {}", roomId, userId);
+    }
+
+    // 참가자 음소거 해제
+    @Transactional
+    public void unmuteParticipant(Long roomId, Long userId) {
+        log.info("참가자 음소거 해제 - 방ID: {}, 사용자ID: {}", roomId, userId);
+
+        Participant participant = findActiveParticipant(roomId, userId);
+        participant.unmute();
+
+        log.info("✅ 참가자 음소거 해제 완료 - 방ID: {}, 사용자ID: {}", roomId, userId);
+    }
+
+    // 참가자 강퇴
+    @Transactional
+    public void banParticipant(Long roomId, Long userId) {
+        log.warn("참가자 강퇴 시작 - 방ID: {}, 사용자ID: {}", roomId, userId);
+
+        Participant participant = findActiveParticipant(roomId, userId);
+        participant.ban();
+
+        long remainingCount = participantRepository.countActiveParticipantsByRoomId(roomId);
+        log.warn("⚠️ 참가자 강퇴 완료 - 방ID: {}, 사용자ID: {}, 남은 참가자 수: {}",
+                roomId, userId, remainingCount);
+    }
+
+    // 방장 나가면 방 삭제
+    @Transactional
+    public void deleteAllParticipantsByRoom(Long roomId) {
+        log.warn("방 삭제로 인한 참가 이력 삭제 - 방ID: {}", roomId);
+
+        long participantCount = participantRepository.countActiveParticipantsByRoomId(roomId);
+        participantRepository.deleteByRoomId(roomId);
+
+        log.warn("⚠️ 참가 이력 삭제 완료 - 방ID: {}, 삭제된 참가자 수: {}", roomId, participantCount);
+    }
+
 }

--- a/src/main/java/org/oreo/smore/domain/participant/exception/ParticipantException.java
+++ b/src/main/java/org/oreo/smore/domain/participant/exception/ParticipantException.java
@@ -1,0 +1,99 @@
+package org.oreo.smore.domain.participant.exception;
+
+public class ParticipantException extends RuntimeException {
+  public ParticipantException(String message) {
+    super(message);
+  }
+
+  public ParticipantException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  // 참가자를 찾을 수 없는 경우
+  public static class ParticipantNotFoundException extends ParticipantException {
+    public ParticipantNotFoundException(String message) {
+      super(message);
+    }
+
+    public ParticipantNotFoundException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  //  스터디룸을 찾을 수 없는 경우
+  public static class StudyRoomNotFoundException extends ParticipantException {
+    public StudyRoomNotFoundException(String message) {
+      super(message);
+    }
+
+    public StudyRoomNotFoundException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  // 이미 참가중인 경우
+  public static class AlreadyJoinedException extends ParticipantException {
+    public AlreadyJoinedException(String message) {
+      super(message);
+    }
+
+    public AlreadyJoinedException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  // 강퇴된 사용자가 재입장을 시도하는 경우
+  public static class BannedUserException extends ParticipantException {
+    public BannedUserException(String message) {
+      super(message);
+    }
+
+    public BannedUserException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  // 방이 가득 찬 경우
+  public static class RoomFullException extends ParticipantException {
+    public RoomFullException(String message) {
+      super(message);
+    }
+
+    public RoomFullException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  // 권한이 없는 경우 (방장이 아닌 사용자가 관리 기능 시도)
+  public static class UnauthorizedAccessException extends ParticipantException {
+    public UnauthorizedAccessException(String message) {
+      super(message);
+    }
+
+    public UnauthorizedAccessException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  // 참가자 상태 변경 불가능한 경우 (이미 퇴장했거나 강퇴된 사용자)
+  public static class InvalidParticipantStateException extends ParticipantException {
+    public InvalidParticipantStateException(String message) {
+      super(message);
+    }
+
+    public InvalidParticipantStateException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
+  // 방장 자신을 대상으로 하는 잘못된 작업 (방장이 자신을 강퇴하려고 시도 등)
+  public static class InvalidOwnerOperationException extends ParticipantException {
+    public InvalidOwnerOperationException(String message) {
+      super(message);
+    }
+
+    public InvalidOwnerOperationException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomCreationService.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomCreationService.java
@@ -238,12 +238,14 @@ public class StudyRoomCreationService {
     private void logCreationStatistics(StudyRoom studyRoom) {
         log.info("스터디룸 생성 통계 - " +
                         "방ID: {}, " +
+                        "방장ID: {}, " +
                         "카테고리: [{}], " +
                         "비밀방여부: {}, " +
                         "최대인원: {}명, " +
                         "타이머설정: {}, " +
                         "생성시간: {}",
                 studyRoom.getRoomId(),
+                studyRoom.getUserId(),
                 studyRoom.getCategory(),
                 studyRoom.getPassword() != null ? "예" : "아니오",
                 studyRoom.getMaxParticipants(),

--- a/src/test/java/org/oreo/smore/domain/participant/ParticipantTest.java
+++ b/src/test/java/org/oreo/smore/domain/participant/ParticipantTest.java
@@ -1,0 +1,162 @@
+package org.oreo.smore.domain.participant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Participant 엔티티 테스트")
+class ParticipantTest {
+
+    private Long roomId;
+    private Long userId;
+    private Participant participant;
+
+    @BeforeEach
+    void setUp() {
+        roomId = 1L;
+        userId = 123L;
+        participant = Participant.builder()
+                .roomId(roomId)
+                .userId(userId)
+                .build();
+
+        System.out.println("🔧 테스트 준비 완료 - 방ID: " + roomId + ", 사용자ID: " + userId);
+    }
+
+    @Test
+    @DisplayName("참가자 객체 생성 시 기본값 설정 확인")
+    void 참가자_객체_생성_시_기본값_설정_확인() {
+        // When & Then
+        assertThat(participant.getRoomId()).isEqualTo(roomId);
+        assertThat(participant.getUserId()).isEqualTo(userId);
+        assertThat(participant.getIsMuted()).isFalse();
+        assertThat(participant.getIsBanned()).isFalse();
+        assertThat(participant.getLeftAt()).isNull();
+        assertThat(participant.getJoinedAt()).isNull(); // @CreatedDate는 실제 저장시에만 설정됨
+
+        System.out.println("✅ 참가자 기본값 설정 확인 완료");
+        System.out.println("   - 음소거 상태: " + participant.getIsMuted());
+        System.out.println("   - 강퇴 상태: " + participant.getIsBanned());
+        System.out.println("   - 퇴장 시간: " + participant.getLeftAt());
+    }
+
+
+    @Test
+    @DisplayName("참가자 음소거 설정 테스트")
+    void 참가자_음소거_설정_테스트() {
+        // Given
+        assertThat(participant.getIsMuted()).isFalse();
+
+        // When
+        participant.mute();
+
+        // Then
+        assertThat(participant.getIsMuted()).isTrue();
+        assertThat(participant.isMutedInRoom()).isTrue();
+
+        System.out.println("✅ 참가자 음소거 설정 테스트 완료");
+        System.out.println("   - 음소거 상태: " + participant.getIsMuted());
+    }
+
+    @Test
+    @DisplayName("참가자 음소거 해제 테스트")
+    void 참가자_음소거_해제_테스트() {
+        // Given
+        participant.mute();
+        assertThat(participant.getIsMuted()).isTrue();
+
+        // When
+        participant.unmute();
+
+        // Then
+        assertThat(participant.getIsMuted()).isFalse();
+        assertThat(participant.isMutedInRoom()).isFalse();
+
+        System.out.println("✅ 참가자 음소거 해제 테스트 완료");
+        System.out.println("   - 음소거 상태: " + participant.getIsMuted());
+    }
+
+    @Test
+    @DisplayName("방 존재 여부 확인 - 정상 참가자")
+    void 방_존재_여부_확인_정상_참가자() {
+        // When & Then
+        assertThat(participant.isInRoom()).isTrue();
+
+        System.out.println("✅ 정상 참가자 방 존재 확인 완료");
+        System.out.println("   - 방에 있음: " + participant.isInRoom());
+    }
+
+    @Test
+    @DisplayName("방 존재 여부 확인 - 퇴장한 참가자")
+    void 방_존재_여부_확인_퇴장한_참가자() {
+        // Given
+        participant.leave();
+
+        // When & Then
+        assertThat(participant.isInRoom()).isFalse();
+
+        System.out.println("✅ 퇴장한 참가자 방 존재 확인 완료");
+        System.out.println("   - 방에 있음: " + participant.isInRoom());
+    }
+
+    @Test
+    @DisplayName("방 존재 여부 확인 - 강퇴당한 참가자")
+    void 방_존재_여부_확인_강퇴당한_참가자() {
+        // Given
+        participant.ban();
+
+        // When & Then
+        assertThat(participant.isInRoom()).isFalse();
+        assertThat(participant.isBannedFromRoom()).isTrue();
+
+        System.out.println("✅ 강퇴당한 참가자 방 존재 확인 완료");
+        System.out.println("   - 방에 있음: " + participant.isInRoom());
+        System.out.println("   - 강퇴됨: " + participant.isBannedFromRoom());
+    }
+
+    @Test
+    @DisplayName("음소거 상태 토글 테스트")
+    void 음소거_상태_토글_테스트() {
+        // Given
+        assertThat(participant.isMutedInRoom()).isFalse();
+
+        // When - 음소거 설정
+        participant.mute();
+
+        // Then
+        assertThat(participant.isMutedInRoom()).isTrue();
+
+        // When - 음소거 해제
+        participant.unmute();
+
+        // Then
+        assertThat(participant.isMutedInRoom()).isFalse();
+
+        System.out.println("✅ 음소거 상태 토글 테스트 완료");
+        System.out.println("   - 최종 음소거 상태: " + participant.isMutedInRoom());
+    }
+
+    @Test
+    @DisplayName("강퇴 후 음소거 상태 변경 불가 테스트")
+    void 강퇴_후_음소거_상태_변경_테스트() {
+        // Given
+        participant.ban();
+        assertThat(participant.isBannedFromRoom()).isTrue();
+
+        // When - 강퇴된 상태에서 음소거 설정 시도
+        participant.mute();
+
+        // Then - 음소거는 설정되지만 방에는 없는 상태
+        assertThat(participant.isMutedInRoom()).isTrue();
+        assertThat(participant.isInRoom()).isFalse();
+
+        System.out.println("✅ 강퇴 후 음소거 상태 변경 테스트 완료");
+        System.out.println("   - 강퇴 상태: " + participant.isBannedFromRoom());
+        System.out.println("   - 음소거 상태: " + participant.isMutedInRoom());
+        System.out.println("   - 방에 있음: " + participant.isInRoom());
+    }
+}


### PR DESCRIPTION
## Summary
Participant 도메인을 구현했습니다.
스터디룸 참가자의 입장/퇴장, 음소거/강퇴 처리 로직 및 관련 DB 연동, 예외 처리를 포함합니다.

## Changes
feat: Participant 엔티티 구현

feat: ParticipantRepository 구현

feat: ParticipantService 참가자 등록, 퇴장, 강퇴, 음소거 등 핵심 기능 구현

feat: Participant 관련 커스텀 예외 처리 클래스 추가

feat: VideoCallController에 참가자 입장/퇴장/재입장 API 추가

feat: 방 삭제 시 참가자 이력 삭제 기능 추가

test: Participant 엔티티 단위 테스트 작성

merge: develop → feature/openvidu 브랜치 병합

## Details
엔티티 구현

Participant 엔티티에 참가자의 roomId, userId, joinedAt, leftAt, isMuted, isBanned 필드 포함

입장/퇴장/강퇴/음소거 상태 변경 메서드 추가 및 로그 출력

Repository

방 ID, 사용자 ID 기준 조회 쿼리

현재 참가자 수, 음소거 참가자 목록 조회

참가 이력 삭제 메서드 등 포함

Service

참가자 등록: 방 존재, 정원 확인, 중복 참가 여부 확인 후 등록

퇴장 처리: 활성 참가자 조회 후 leftAt 설정

강퇴, 음소거/해제, 참가자 상태 검증 등 도메인 로직 구현

방장 퇴장 시 방 삭제와 함께 모든 참가자 이력 삭제

예외 처리

ParticipantException: 참가자 관련 예외를 커스텀 클래스로 분리

방 존재하지 않음, 정원 초과, 중복 참가, 강퇴된 사용자 등 상황별 예외 정의

Controller

joinRoom: 입장 요청 시 DB에 참가자 등록 후 토큰 발급

rejoinRoom: 재입장 요청 시 참가 여부 확인 후 토큰 재발급

leaveRoom: 개별 퇴장 처리 API

deleteStudyRoom: 방장 퇴장 시 방 삭제 (미구현 상태 로그만 작성됨)

테스트

Participant 객체 생성 기본값 확인

입장/퇴장/강퇴/음소거 상태 전환 및 확인 테스트

강퇴된 상태에서 음소거 등 경계 상황 테스트 포함