### PR TITLE
Feat: gms 연동을 통한 ai 피드백 구현

### DIFF
--- a/src/main/java/org/oreo/smore/domain/focusrecord/FocusFeedbackService.java
+++ b/src/main/java/org/oreo/smore/domain/focusrecord/FocusFeedbackService.java
@@ -1,138 +1,145 @@
-//package org.oreo.smore.domain.focusrecord;
-//
-//import com.fasterxml.jackson.databind.JsonNode;
-//import lombok.RequiredArgsConstructor;
-//import org.oreo.smore.domain.focusrecord.dto.FocusTimeDto;
-//import org.oreo.smore.domain.focusrecord.dto.FocusTrackDto;
-//import org.slf4j.Logger;
-//import org.slf4j.LoggerFactory;
-//import org.springframework.http.HttpHeaders;
-//import org.springframework.http.HttpStatusCode;
-//import org.springframework.stereotype.Service;
-//import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
-//import org.springframework.web.reactive.function.client.WebClient;
-//import org.springframework.web.reactive.function.client.WebClientResponseException;
-//import reactor.core.publisher.Mono;
-//
-//import java.time.Duration;
-//import java.util.List;
-//import java.util.Map;
-//import java.util.concurrent.ThreadLocalRandom;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class FocusFeedbackService {
-//    private static final Logger log = LoggerFactory.getLogger(FocusFeedbackService.class);
-//
-//    private final WebClient client;
-//    private final GmsProperties props;
-//
-//    // 1) 기본 격려 문구 10개
-//    private static final List<String> DEFAULT_FEEDBACKS = List.of(
-//            "훌륭해요! 꾸준히 이어가면 분명 좋은 결과가 있을 거예요😊",
-//            "오늘도 최선을 다했어요! 내일 더 멋지게 해봐요!",
-//            "멋져요! 당신의 노력은 꼭 빛을 발할 거예요!",
-//            "잘하고 있어요! 잠깐의 휴식도 잊지 마세요!",
-//            "당신의 집중력, 정말 대단해요! 계속 힘내요!",
-//            "지금까지 잘해왔어요! 앞으로도 파이팅!",
-//            "한 걸음 한 걸음이 모여 큰 성장을 만듭니다!",
-//            "집중하는 모습, 정말 멋져요! 계속 이어가요!",
-//            "당신의 노력에 박수를 보냅니다! 언제나 응원해요!",
-//            "오늘의 성과도 소중해요! 내일도 기대할게요!"
-//    );
-//
-//    public FocusFeedbackService(WebClient.Builder webClientBuilder,
-//                                GmsProperties props) {
-//        this.props = props;
-//
-//        ExchangeFilterFunction requestLogger = ExchangeFilterFunction.ofRequestProcessor(r -> {
-//            log.info("▶ GMS 피드백 요청 ▶ {} {}", r.method(), r.url());
-//            return Mono.just(r);
-//        });
-//        ExchangeFilterFunction responseLogger = ExchangeFilterFunction.ofResponseProcessor(r -> {
-//            log.info("◀ GMS 피드백 응답 ◀ {}", r.statusCode());
-//            return Mono.just(r);
-//        });
-//
-//        this.client = webClientBuilder
-//                .baseUrl(props.getEndpoint())
-//                .filter(requestLogger)
-//                .filter(responseLogger)
-//                .build();
-//    }
-//
-//    /**
-//     * best, worst, avgDurationSeconds, track 정보를 보고
-//     * 한 줄짜리 피드백을 GMS에 요청해서 받아옵니다.
-//     */
-//    public String generateOneLineFeedback(FocusTimeDto best,
-//                                          FocusTimeDto worst,
-//                                          int avgDurationSeconds,
-//                                          FocusTrackDto track) {
-//        // 1) system prompt: 역할 정의
-//        String systemPrompt = """
-//            당신은 집중도 분석 데이터를 보고 '딱 한 줄'의 간결한 피드백을 작성하는 AI입니다.
-//            - 톤: 따뜻하고 격려하는
-//            - 길이: 최대 1문장
-//            - 예시) "오전 집중력이 최고니, 이 시간대에 가장 중요한 학습을 배치해 보세요!"
-//            """;
-//
-//        // 2) user prompt: 실제 데이터 삽입
-//        String userPrompt = String.format("""
-//            최고 집중 시간대: %s~%s (평균점수: %d)
-//            최저 집중 시간대: %s~%s (평균점수: %d)
-//            평균 집중 유지 시간: %d초
-//            시간대별 집중도: %s
-//            위 정보를 바탕으로 한 줄 피드백을 작성해 주세요.
-//            """,
-//                best.getStart(), best.getEnd(), best.getAvgFocusScore(),
-//                worst.getStart(), worst.getEnd(), worst.getAvgFocusScore(),
-//                avgDurationSeconds,
-//                track.getScores().toString()
-//        );
-//
-//        Map<String,Object> body = Map.of(
-//                "model", "gpt-4o",
-//                "messages", List.of(
-//                        Map.of("role", "system",  "content", systemPrompt),
-//                        Map.of("role", "user",    "content", userPrompt)
-//                )
-//        );
-//
-//        JsonNode resp;
-//        try {
-//            resp = client.post()
-//                    .uri("/v1/chat/completions")
-//                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + props.getKey())
-//                    .bodyValue(body)
-//                    .retrieve()
-//                    .onStatus(HttpStatusCode::isError, cr ->
-//                            cr.bodyToMono(String.class)
-//                                    .flatMap(errBody -> {
-//                                        log.error("GMS 피드백 호출 에러 {}: {}", cr.statusCode(), errBody);
-//                                        return Mono.error(new RuntimeException("GMS error: " + errBody));
-//                                    })
-//                    )
-//                    .bodyToMono(JsonNode.class)
-//                    .timeout(Duration.ofSeconds(5))
-//                    .block();
-//        } catch (WebClientResponseException e) {
-//            log.error("GMS 피드백 호출 실패: {} / {}", e.getRawStatusCode(), e.getResponseBodyAsString());
-//            return getRandomDefaultFeedback();
-//        }
-//
-//        // 3) 결과 리턴
-//        return resp
-//                .path("choices")
-//                .get(0)
-//                .path("message")
-//                .path("content")
-//                .asText()
-//                .trim();
-//    }
-//
-//    private String getRandomDefaultFeedback() {
-//        int randomIdx = ThreadLocalRandom.current().nextInt(DEFAULT_FEEDBACKS.size());
-//        return DEFAULT_FEEDBACKS.get(randomIdx);
-//    }
-//}
+package org.oreo.smore.domain.focusrecord;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.oreo.smore.domain.focusrecord.dto.FocusRecordsResponse;
+import org.oreo.smore.global.common.GmsProperties;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.*;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Service
+public class FocusFeedbackService {
+    private final WebClient client;
+    private final GmsProperties props;
+
+    static final List<String> DEFAULT_FEEDBACKS = List.of(
+            "훌륭해요! 꾸준히 이어가면 분명 좋은 결과가 있을 거예요😊",
+            "오늘도 최선을 다했어요! 내일 더 멋지게 해봐요!",
+            "멋져요! 당신의 노력은 꼭 빛을 발할 거예요!",
+            "잘하고 있어요! 잠깐의 휴식도 잊지 마세요!",
+            "당신의 집중력, 정말 대단해요! 계속 힘내요!",
+            "지금까지 잘해왔어요! 앞으로도 파이팅!",
+            "한 걸음 한 걸음이 모여 큰 성장을 만듭니다!",
+            "집중하는 모습, 정말 멋져요! 계속 이어가요!",
+            "당신의 노력에 박수를 보냅니다! 언제나 응원해요!",
+            "오늘의 성과도 소중해요! 내일도 기대할게요!"
+    );
+
+    public FocusFeedbackService(WebClient.Builder webClientBuilder,
+                                GmsProperties props) {
+        this.props = props;
+
+        ExchangeFilterFunction requestLogger = ExchangeFilterFunction.ofRequestProcessor(r -> {
+            log.info("▶ GMS 피드백 요청 ▶ {} {}", r.method(), r.url());
+            return Mono.just(r);
+        });
+        ExchangeFilterFunction responseLogger = ExchangeFilterFunction.ofResponseProcessor(r -> {
+            log.info("◀ GMS 피드백 응답 ◀ {}", r.statusCode());
+            return Mono.just(r);
+        });
+
+        // endpoint: https://gms.ssafy.io/gmsapi
+        this.client = webClientBuilder
+                .baseUrl(props.getEndpoint())
+                .filter(requestLogger)
+                .filter(responseLogger)
+                .build();
+    }
+
+    public String generateOneLineFeedback(
+            FocusRecordsResponse.FocusTimeDto best,
+            FocusRecordsResponse.FocusTimeDto worst,
+            int avgDurationSeconds,
+            FocusRecordsResponse.FocusTrackDto track) {
+
+        String systemPrompt = """
+                당신은 심리학 기반의 생산성 코칭 전문가입니다.
+                • 제공된 시간 정보는 반복 금지해 주세요.
+                • 집중력 ‘급등·급락’ 원인·주의점 1문장,  
+                  구체적 실천 팁 또는 응원 1문장(숫자 포함)을 작성합니다.
+                • 톤은 더욱 친근하고 부드럽게,  
+                  다양한 이모지(😊✨🎉👍🔋💤💡📈)를 활용하세요.
+                • 전체를 “최대 2문장”으로 구성하고,  
+                  반드시 아래 예시 스타일을 모방합니다.
+                
+                —— 예시 시작 ——
+                집중력이 들쭉날쭉한 건 수면 루틴이 들쭉날쭉해서 그런 것 같아요😴.  
+                25분 집중 후 5분 휴식(예: 하루 4회 이상)을 시도해 리듬을 찾아보세요💪
+                —— 예시 끝 ——
+                """;
+
+        String userPrompt = String.format("""
+                        최고 집중 시간대: %s~%s (평균점수: %d)
+                        최저 집중 시간대: %s~%s (평균점수: %d)
+                        평균 유지 시간: %d초
+                        시간대별 집중도: %s
+                        위 데이터로부터 “시간 언급 없이”  
+                        원인·주의점·실천 팁 또는 응원을  
+                        예시 스타일과 같이 친근한 어투 & 다양한 이모지 포함해  
+                        최대 2문장으로 작성해 주세요.
+                        """,
+                best.getStart(), best.getEnd(), best.getAvgFocusScore(),
+                worst.getStart(), worst.getEnd(), worst.getAvgFocusScore(),
+                avgDurationSeconds,
+                track.getScores().toString()
+        );
+
+
+        // max_tokens, temperature 추가
+        Map<String, Object> body = Map.of(
+                "model", "gpt-4.1-nano",
+                "messages", List.of(
+                        Map.of("role", "system", "content", systemPrompt),
+                        Map.of("role", "user", "content", userPrompt)
+                ),
+                "max_tokens", 4096,
+                "temperature", 0.3
+        );
+
+        JsonNode resp;
+        try {
+            resp = client.post()
+                    // proxy 경유 경로를 포함
+                    .uri("/api.openai.com/v1/chat/completions")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + props.getKey())
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .bodyValue(body)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, cr ->
+                            cr.bodyToMono(String.class)
+                                    .flatMap(err -> {
+                                        log.error("GMS 피드백 에러 {}: {}", cr.statusCode(), err);
+                                        return Mono.error(new RuntimeException(err));
+                                    })
+                    )
+                    .bodyToMono(JsonNode.class)
+                    .timeout(Duration.ofSeconds(5))
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.error("GMS 호출 실패: {} / {}", e.getRawStatusCode(), e.getResponseBodyAsString());
+            return getRandomDefaultFeedback();
+        }
+
+        return resp.path("choices")
+                .get(0)
+                .path("message")
+                .path("content")
+                .asText()
+                .trim();
+    }
+
+    private String getRandomDefaultFeedback() {
+        int idx = ThreadLocalRandom.current().nextInt(DEFAULT_FEEDBACKS.size());
+        return DEFAULT_FEEDBACKS.get(idx);
+    }
+}

--- a/src/main/java/org/oreo/smore/domain/focusrecord/FocusRecordService.java
+++ b/src/main/java/org/oreo/smore/domain/focusrecord/FocusRecordService.java
@@ -31,6 +31,8 @@ public class FocusRecordService {
             .collect(Collectors.toUnmodifiableList());
 
     private final FocusRecordRepository focusRecordRepository;
+    private final FocusFeedbackService focusFeedbackService;
+
 
     public FocusRecordsResponse getFocusRecords(Long userId, String timeZoneOffset) {
         ZoneOffset clientOffset = ZoneOffset.of(timeZoneOffset);
@@ -169,8 +171,7 @@ public class FocusRecordService {
     private String generateFeedback(
             FocusTimeDto best, FocusTimeDto worst,
             int avgDuration, FocusTrackDto track) {
-        // TODO: GMS 연동 필요
-        return "아침형 스타일입니다. 등교 전 오전에 50분 집중 후 10분 휴식을 추천드립니다 😊";
+        return focusFeedbackService.generateOneLineFeedback(best, worst, avgDuration, track);
     }
 
     private record HourlyStats(

--- a/src/main/java/org/oreo/smore/global/common/GmsProperties.java
+++ b/src/main/java/org/oreo/smore/global/common/GmsProperties.java
@@ -1,0 +1,27 @@
+package org.oreo.smore.global.common;
+
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "gms.api")
+public class GmsProperties {
+
+    private String endpoint;
+    private String key;
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getKey() {
+        return key;
+    }
+    public void setKey(String key) {
+        this.key = key;
+    }
+}

--- a/src/main/java/org/oreo/smore/global/config/WebClientConfig.java
+++ b/src/main/java/org/oreo/smore/global/config/WebClientConfig.java
@@ -1,0 +1,44 @@
+package org.oreo.smore.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.oreo.smore.global.common.GmsProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Configuration
+public class WebClientConfig {
+
+    /**
+     * WebClient.Builder 빈 등록.
+     * 이 Builder를 주입받아, FocusFeedbackService 에서
+     * .baseUrl(), .filter() 등을 설정할 수 있습니다.
+     */
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+
+    /**
+     * (선택) GMS 전용 WebClient 빈 등록.
+     * GmsProperties 를 주입받아 baseUrl 과 로깅 필터를 미리 설정해두고 싶다면
+     * 아래처럼 WebClient 빈을 직접 정의해도 됩니다.
+     */
+    @Bean
+    public WebClient gmsWebClient(WebClient.Builder builder, GmsProperties props) {
+        return builder
+                .baseUrl(props.getEndpoint())
+                .filter(ExchangeFilterFunction.ofRequestProcessor(req -> {
+                    log.info("▶ GMS 요청 ▶ {} {}", req.method(), req.url());
+                    return Mono.just(req);
+                }))
+                .filter(ExchangeFilterFunction.ofResponseProcessor(res -> {
+                    log.info("◀ GMS 응답 ◀ {}", res.statusCode());
+                    return Mono.just(res);
+                }))
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,11 @@ spring:
             redirect-uri: ${OAUTH2_REDIRECT_URI:${baseUrl}/login/oauth2/code/{registrationId}}
             client-name: Google
 
+gms:
+  api:
+    endpoint: ${GMS_API_ENDPOINT}
+    key: ${GMS_API_KEY}
+
 app:
   oauth2:
     frontend:

--- a/src/test/java/org/oreo/smore/domain/focusrecord/FocusFeedbackIntegrationTest.java
+++ b/src/test/java/org/oreo/smore/domain/focusrecord/FocusFeedbackIntegrationTest.java
@@ -1,0 +1,43 @@
+package org.oreo.smore.domain.focusrecord;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.oreo.smore.domain.focusrecord.dto.FocusRecordsResponse.FocusTimeDto;
+import org.oreo.smore.domain.focusrecord.dto.FocusRecordsResponse.FocusTrackDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")   // application-test.yml 사용
+class FocusFeedbackIntegrationTest {
+
+    @Autowired
+    private FocusFeedbackService feedbackService;
+
+//    @Test
+//    @DisplayName("실제 GMS 연동 테스트")
+//    void realGmsCall_returnsNonEmptyFeedback() {
+//        // ## 1) 테스트용 데이터 준비
+//        FocusTimeDto best  = new FocusTimeDto("09:00", "11:00", 90);
+//        FocusTimeDto worst = new FocusTimeDto("02:00", "04:00", 10);
+//        FocusTrackDto track = new FocusTrackDto(
+//                List.of("00","01","02","03","04","05","06","07","08","09","10","11","12","13","14","15","16","17","18","19","20","21","22","23"),
+//                List.of(10,10,10,10,10,10,10,10,10,90,10,10,10,10,10,10,10,10,10,10,10,10,10,10)
+//        );
+//
+//        // ## 2) 실제 호출
+//        String feedback = feedbackService.generateOneLineFeedback(best, worst, 3600, track);
+//
+//        // ## 3) 결과 검증
+//        assertNotNull(feedback, "피드백이 null 이면 안 됩니다");
+//        assertFalse(feedback.isBlank(), "빈 문자열이 아니어야 합니다");
+//
+//        // (선택) 콘솔에 찍어보기
+//        System.out.println("▶ 실제 GMS 피드백: " + feedback);
+//    }
+}

--- a/src/test/java/org/oreo/smore/domain/focusrecord/FocusRecordControllerTest.java
+++ b/src/test/java/org/oreo/smore/domain/focusrecord/FocusRecordControllerTest.java
@@ -6,7 +6,9 @@ import org.mockito.*;
 import org.oreo.smore.domain.focusrecord.dto.FocusRecordsResponse;
 import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -48,7 +50,7 @@ class FocusRecordControllerTest {
 
         ResponseEntity<Object> resp = controller.getFocusRecords(userId, tz, auth);
 
-        assertEquals(HttpStatus.UNAUTHORIZED, resp.getStatusCode());
+        assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
         assertNull(resp.getBody());
     }
 }


### PR DESCRIPTION
## Summary
GMS 연동을 통해 AI 기반 한 줄 피드백 생성 기능을 구현하고, 관련 설정 및 테스트를 추가했습니다.

## Changes
- feat: FocusFeedbackService에 GMS API 호출 로직 구현
- feat: WebClientConfig에 WebClient.Builder 및 GMS 전용 WebClient 빈 등록
- chore: application.yml에 gms.api.endpoint 및 gms.api.key 설정 추가
- test: FocusFeedbackIntegrationTest 추가 (실제 GMS 연동 테스트 스켈레톤)
- test: FocusRecordControllerTest 권한 예외 검증 로직 수정
- test: FocusRecordServiceTest에 FocusFeedbackService 목 빈 선언 및 피드백 검증 로직 추가

## Details
FocusFeedbackService
기존: 정적 기본 피드백만 반환하도록 주석 처리되어 있던 AI 호출 로직
변경: GMS 연동을 통한 피드백 반환