### PR TITLE
Fix: 스터디룸 조회 dto 수정

### DIFF
--- a/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomController.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.oreo.smore.domain.studyroom.dto.CreateStudyRoomRequest;
 import org.oreo.smore.domain.studyroom.dto.CreateStudyRoomResponse;
-import org.oreo.smore.domain.studyroom.dto.StudyRoomDto;
+import org.oreo.smore.domain.studyroom.dto.StudyRoomInfoReadResponse;
 import org.oreo.smore.global.common.CursorPage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -47,7 +47,7 @@ public class StudyRoomController {
     }
 
     @GetMapping
-    public ResponseEntity<CursorPage<StudyRoomDto>> listStudyRooms(
+    public ResponseEntity<CursorPage<StudyRoomInfoReadResponse>> listStudyRooms(
             @RequestParam(name="page", defaultValue="1") Long page,
             @RequestParam(name="limit", defaultValue="20") int limit,
             @RequestParam(name="search", required=false) String search,
@@ -55,7 +55,7 @@ public class StudyRoomController {
             @RequestParam(name="sort", defaultValue="latest") String sort,
             @RequestParam(name="hide-full-rooms", defaultValue="false") boolean hideFullRooms
     ) {
-        CursorPage<StudyRoomDto> studyRoomDtoCursorPage = studyRoomService.listStudyRooms(page, limit, search, category, sort, hideFullRooms);
+        CursorPage<StudyRoomInfoReadResponse> studyRoomDtoCursorPage = studyRoomService.listStudyRooms(page, limit, search, category, sort, hideFullRooms);
         return ResponseEntity.ok(studyRoomDtoCursorPage);
     }
 }

--- a/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomService.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomService.java
@@ -5,7 +5,7 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
 import org.oreo.smore.domain.participant.ParticipantRepository;
-import org.oreo.smore.domain.studyroom.dto.StudyRoomDto;
+import org.oreo.smore.domain.studyroom.dto.StudyRoomInfoReadResponse;
 import org.oreo.smore.global.common.CursorPage;
 import org.oreo.smore.domain.user.User;
 import org.oreo.smore.domain.user.UserRepository;
@@ -25,7 +25,7 @@ public class StudyRoomService {
     private final ParticipantRepository participantRepository;
     private final UserRepository userRepo;
 
-    public CursorPage<StudyRoomDto> listStudyRooms(
+    public CursorPage<StudyRoomInfoReadResponse> listStudyRooms(
             Long page,
             int limit,
             String search,
@@ -38,7 +38,7 @@ public class StudyRoomService {
         Pageable pageable = PageRequest.of(0, limit + 1, sortOrder);
 
         List<StudyRoom> rooms = fetchRooms(cursor, search, category, pageable);
-        List<StudyRoomDto> dtos = mapAndFilterRooms(rooms, hideFullRooms);
+        List<StudyRoomInfoReadResponse> dtos = mapAndFilterRooms(rooms, hideFullRooms);
         if (isPopularSort(sort)) {
             applyPopularSort(dtos);
         }
@@ -101,7 +101,7 @@ public class StudyRoomService {
         }
     }
 
-    private List<StudyRoomDto> mapAndFilterRooms(
+    private List<StudyRoomInfoReadResponse> mapAndFilterRooms(
             List<StudyRoom> rooms,
             boolean hideFullRooms
     ) {
@@ -111,19 +111,19 @@ public class StudyRoomService {
                 .collect(Collectors.toList());
     }
 
-    private StudyRoomDto toDto(StudyRoom room) {
+    private StudyRoomInfoReadResponse toDto(StudyRoom room) {
         long count = participantRepository.countByRoomIdAndLeftAtIsNull(room.getRoomId());
         User creator = userRepo.findById(room.getUserId())
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND,
                         "Creator not found: " + room.getUserId()
                 ));
-        return StudyRoomDto.of(room, count, creator.getNickname());
+        return StudyRoomInfoReadResponse.of(room, count, creator.getNickname());
     }
 
-    private void applyPopularSort(List<StudyRoomDto> dtos) {
+    private void applyPopularSort(List<StudyRoomInfoReadResponse> dtos) {
         dtos.sort(
-                Comparator.comparingLong(StudyRoomDto::getCurrentParticipants).reversed()
+                Comparator.comparingLong(StudyRoomInfoReadResponse::getCurrentParticipants).reversed()
         );
     }
 }

--- a/src/main/java/org/oreo/smore/domain/studyroom/dto/StudyRoomInfoReadResponse.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/dto/StudyRoomInfoReadResponse.java
@@ -1,10 +1,9 @@
-// src/main/java/org/oreo/smore/domain/studyroom/dto/StudyRoomDto.java
 package org.oreo.smore.domain.studyroom.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 import org.oreo.smore.global.common.CursorPage.Identifiable;
 import org.oreo.smore.domain.studyroom.StudyRoom;
 
@@ -17,7 +16,8 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @Builder
-public class StudyRoomDto implements Identifiable {
+@ToString
+public class StudyRoomInfoReadResponse implements Identifiable {
     private Long roomId;
 
     private String title;
@@ -36,6 +36,10 @@ public class StudyRoomDto implements Identifiable {
 
     private String createdAt;
 
+    private Boolean isPomodoro;
+
+    private Boolean isPrivate;
+
     private CreatorDto creator;
 
     @Override
@@ -52,7 +56,7 @@ public class StudyRoomDto implements Identifiable {
     /**
      * 엔티티 + 집계값 → DTO
      */
-    public static StudyRoomDto of(
+    public static StudyRoomInfoReadResponse of(
             StudyRoom e,
             long       currentParticipants,
             String     creatorNickname
@@ -64,7 +68,7 @@ public class StudyRoomDto implements Identifiable {
                 .atOffset(ZoneOffset.UTC)
                 .format(DateTimeFormatter.ISO_INSTANT);
 
-        return new StudyRoomDto(
+        return new StudyRoomInfoReadResponse(
                 e.getRoomId(),
                 e.getTitle(),
                 e.getThumbnailUrl(),
@@ -74,6 +78,8 @@ public class StudyRoomDto implements Identifiable {
                 currentParticipants,
                 e.getPassword(),
                 created,
+                e.getFocusTime() == null,
+                !(e.getPassword() == null || e.getPassword().isEmpty()),
                 new CreatorDto(creatorNickname)
         );
     }

--- a/src/test/java/org/oreo/smore/domain/studyroom/StudyRoomControllerTest.java
+++ b/src/test/java/org/oreo/smore/domain/studyroom/StudyRoomControllerTest.java
@@ -2,7 +2,7 @@ package org.oreo.smore.domain.studyroom;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.oreo.smore.domain.studyroom.dto.StudyRoomDto;
+import org.oreo.smore.domain.studyroom.dto.StudyRoomInfoReadResponse;
 import org.oreo.smore.global.common.CursorPage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -35,7 +35,7 @@ class StudyRoomControllerTest {
     @DisplayName("GET /v1/study-rooms 조회 시 빈 페이지 반환")
     void listStudyRooms_ShouldReturnEmptyPage() throws Exception {
         // given: Service가 빈 페이지를 반환하도록 Mock 설정
-        CursorPage<StudyRoomDto> emptyPage = new CursorPage<>();
+        CursorPage<StudyRoomInfoReadResponse> emptyPage = new CursorPage<>();
         emptyPage.setCursorId(1L);
         emptyPage.setSize(20);
         emptyPage.setContent(Collections.emptyList());
@@ -66,12 +66,12 @@ class StudyRoomControllerTest {
     @DisplayName("GET /v1/study-rooms 조회 시 기본 정렬(latest) 검증")
     void listStudyRooms_WithSortParam() throws Exception {
         // given: 하나의 더미 DTO 반환
-        StudyRoomDto dto = StudyRoomDto.builder()
+        StudyRoomInfoReadResponse dto = StudyRoomInfoReadResponse.builder()
                 .roomId(100L)
                 .title("테스트 스터디룸")
                 .build();
 
-        CursorPage<StudyRoomDto> page = new CursorPage<>();
+        CursorPage<StudyRoomInfoReadResponse> page = new CursorPage<>();
         page.setCursorId(100L);
         page.setSize(1);
         page.setContent(Collections.singletonList(dto));
@@ -99,11 +99,11 @@ class StudyRoomControllerTest {
     @DisplayName("GET /v1/study-rooms 여러 파라미터로 조회 시 서비스 호출 및 응답 검증")
     void listStudyRooms_WithAllParams() throws Exception {
         // given
-        StudyRoomDto dto = StudyRoomDto.builder()
+        StudyRoomInfoReadResponse dto = StudyRoomInfoReadResponse.builder()
                 .roomId(200L)
                 .title("여러 파람 테스트")
                 .build();
-        CursorPage<StudyRoomDto> page = new CursorPage<>();
+        CursorPage<StudyRoomInfoReadResponse> page = new CursorPage<>();
         page.setCursorId(200L);
         page.setSize(1);
         page.setContent(Collections.singletonList(dto));

--- a/src/test/java/org/oreo/smore/domain/studyroom/StudyRoomServiceTest.java
+++ b/src/test/java/org/oreo/smore/domain/studyroom/StudyRoomServiceTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.oreo.smore.domain.participant.ParticipantRepository;
-import org.oreo.smore.domain.studyroom.dto.StudyRoomDto;
+import org.oreo.smore.domain.studyroom.dto.StudyRoomInfoReadResponse;
 import org.oreo.smore.domain.user.User;
 import org.oreo.smore.domain.user.UserRepository;
 import org.oreo.smore.global.common.CursorPage;
@@ -53,7 +53,7 @@ class StudyRoomServiceTest {
                 .willReturn(new SliceImpl<>(Collections.emptyList(), pageable, false));
 
         // when
-        CursorPage<StudyRoomDto> result =
+        CursorPage<StudyRoomInfoReadResponse> result =
                 studyRoomService.listStudyRooms(null, limit, null, null, null, false);
 
         // then
@@ -92,12 +92,18 @@ class StudyRoomServiceTest {
         given(userRepository.findById(42L)).willReturn(Optional.of(creator));
 
         // when
-        CursorPage<StudyRoomDto> result =
+        CursorPage<StudyRoomInfoReadResponse> result =
                 studyRoomService.listStudyRooms(null, limit, "검색어", "EMPLOYMENT", "latest", true);
 
+
+        System.out.println("result:");
+        for (StudyRoomInfoReadResponse e : result.getContent()) {
+            System.out.println(e);
+        }
+        System.out.println("------");
         // then: DTO 필드들도 category 기반 로직에 맞춰 검증 가능
         assertEquals(1, result.getContent().size());
-        StudyRoomDto dto = result.getContent().get(0);
+        StudyRoomInfoReadResponse dto = result.getContent().get(0);
         assertEquals(100L, dto.getRoomId());
         assertEquals("tester", dto.getCreator().getNickname());
         assertEquals(3, dto.getCurrentParticipants());


### PR DESCRIPTION
## Summary
스터디룸 목록 조회 API의 반환 DTO를 StudyRoomDto에서 StudyRoomInfoReadResponse로 변경하고, 이에 따라 컨트롤러·서비스·DTO·테스트 코드를 일관되게 수정했습니다.

## Changes
- fix: StudyRoomController.listStudyRooms 반환 타입 및 제네릭 변경
- fix: StudyRoomService.listStudyRooms 반환 타입, 매핑 로직 및 인기 정렬 메서드 수정
- refactor: StudyRoomDto 클래스명을 StudyRoomInfoReadResponse로 변경하고 팩토리 메서드 업데이트
- test: StudyRoomControllerTest·StudyRoomServiceTest에서 기대 타입과 빌더 호출 대상 변경

## Details
### StudyRoomController
listStudyRooms() 시그니처의 제네릭을 CursorPage<StudyRoomDto> → CursorPage<StudyRoomInfoReadResponse>로 변경
로컬 변수명 (studyRoomDtoCursorPage)는 동일하되 타입만 업데이트

### StudyRoomService
반환 타입을 CursorPage<StudyRoomDto> → CursorPage<StudyRoomInfoReadResponse>로 변경
mapAndFilterRooms() 내부의 toDto(StudyRoom) 호출이 StudyRoomInfoReadResponse.of(...)를 사용하도록 수정
인기순 정렬 메서드 applyPopularSort()에서 클래스 참조를 StudyRoomInfoReadResponse::getCurrentParticipants로 변경

### DTO (StudyRoomInfoReadResponse)
파일명 및 클래스명을 StudyRoomDto → StudyRoomInfoReadResponse로 리네임
@ToString 애노테이션 추가, 기존 팩토리 메서드 of(StudyRoom, long, String)로 생성
필드 구성 및 JSON 프로퍼티는 기존 DTO와 동일

## Tests

### StudyRoomControllerTest
빈 페이지 반환 테스트 및 파라미터별 조회 테스트에서 CursorPage<StudyRoomInfoReadResponse> 사용
더미 DTO 생성 시 StudyRoomInfoReadResponse.builder() 호출로 변경

### StudyRoomServiceTest
서비스 호출 반환 타입을 CursorPage<StudyRoomInfoReadResponse>로 변경
결과 검증 시 StudyRoomInfoReadResponse의 getRoomId(), getCurrentParticipants(), getCreator().getNickname() 등으로 어설션 업데이트