### PR TITLE
Fix: 참가자 등록 시 DB 제약조건 오류 및 Repository 쿼리 수정

### DIFF
--- a/src/main/java/org/oreo/smore/domain/participant/dto/RoomInfo.java
+++ b/src/main/java/org/oreo/smore/domain/participant/dto/RoomInfo.java
@@ -1,0 +1,10 @@
+package org.oreo.smore.domain.participant.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+
+public class RoomInfo {
+}

--- a/src/main/java/org/oreo/smore/domain/video/dto/JoinRoomRequest.java
+++ b/src/main/java/org/oreo/smore/domain/video/dto/JoinRoomRequest.java
@@ -1,6 +1,7 @@
 package org.oreo.smore.domain.video.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class JoinRoomRequest {
     // 스터디룸 입장 요청 DTO
 
@@ -19,13 +21,6 @@ public class JoinRoomRequest {
 
     private Boolean canSubscribe;
 
-    public JoinRoomRequest(String password, Integer tokenExpirySeconds,
-                           Boolean canPublish, Boolean canSubscribe) {
-        this.password = password;
-        this.tokenExpirySeconds = tokenExpirySeconds != null ? tokenExpirySeconds : 3600;
-        this.canPublish = canPublish != null ? canPublish : true;
-        this.canSubscribe = canSubscribe != null ? canSubscribe : true;
-    }
 
     public Integer getTokenExpirySeconds() {
         return tokenExpirySeconds != null ? tokenExpirySeconds : 3600;

--- a/src/test/java/org/oreo/smore/domain/participant/ParticipantAutoIncrementTest.java
+++ b/src/test/java/org/oreo/smore/domain/participant/ParticipantAutoIncrementTest.java
@@ -1,0 +1,71 @@
+package org.oreo.smore.domain.participant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ParticipantAutoIncrementTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Test
+    void participant_저장시_ID_자동생성_테스트() {
+        // Given
+        Long roomId = 1L;
+        Long userId = 2L;
+
+        // When
+        Participant participant = Participant.builder()
+                .roomId(roomId)
+                .userId(userId)
+                .build();
+
+        System.out.println("저장 전 participantId: " + participant.getParticipantId());
+
+        // DB에 저장
+        Participant saved = participantRepository.save(participant);
+        entityManager.flush(); // 즉시 DB에 반영
+
+        // Then
+        System.out.println("저장 후 participantId: " + saved.getParticipantId());
+        System.out.println("저장 후 joinedAt: " + saved.getJoinedAt());
+
+        assertThat(saved.getParticipantId()).isNotNull();
+        assertThat(saved.getParticipantId()).isGreaterThan(0L);
+        assertThat(saved.getJoinedAt()).isNotNull();
+        assertThat(saved.getRoomId()).isEqualTo(roomId);
+        assertThat(saved.getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void 여러_participant_저장시_ID_증가_테스트() {
+        // Given & When
+        Participant p1 = participantRepository.save(
+                Participant.builder().roomId(1L).userId(2L).build()
+        );
+
+        Participant p2 = participantRepository.save(
+                Participant.builder().roomId(1L).userId(3L).build()
+        );
+
+        entityManager.flush();
+
+        // Then
+        System.out.println("첫 번째 participant ID: " + p1.getParticipantId());
+        System.out.println("두 번째 participant ID: " + p2.getParticipantId());
+
+        assertThat(p1.getParticipantId()).isNotNull();
+        assertThat(p2.getParticipantId()).isNotNull();
+        assertThat(p2.getParticipantId()).isGreaterThan(p1.getParticipantId());
+    }
+}

--- a/src/test/java/org/oreo/smore/domain/participant/ParticipantConnectionTest.java
+++ b/src/test/java/org/oreo/smore/domain/participant/ParticipantConnectionTest.java
@@ -1,0 +1,65 @@
+package org.oreo.smore.domain.participant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import org.oreo.smore.domain.studyroom.StudyRoom;
+import org.oreo.smore.domain.studyroom.StudyRoomRepository;
+import org.oreo.smore.domain.studyroom.StudyRoomCategory;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class ParticipantConnectionTest {
+
+    @Autowired
+    private ParticipantService participantService;
+
+    @Autowired
+    private StudyRoomRepository studyRoomRepository;
+
+    @Test
+    void joinRoom_성공_테스트() {
+        // Given: 먼저 StudyRoom 생성
+        StudyRoom studyRoom = StudyRoom.builder()
+                .title("테스트 방")
+                .category(StudyRoomCategory.SELF_STUDY)
+                .maxParticipants(10)
+                .userId(1L)  // 방장 ID
+                .build();
+
+        StudyRoom savedRoom = studyRoomRepository.save(studyRoom);
+        Long roomId = savedRoom.getRoomId();
+        Long userId = 2L;
+
+        try {
+            // When
+            System.out.println("=== ParticipantService.joinRoom 시작 ===");
+            System.out.println("생성된 방 ID: " + roomId);
+
+            Participant participant = participantService.joinRoom(roomId, userId);
+
+            // Then
+            System.out.println("✅ 참가자 등록 성공!");
+            System.out.println("participantId: " + participant.getParticipantId());
+            System.out.println("roomId: " + participant.getRoomId());
+            System.out.println("userId: " + participant.getUserId());
+            System.out.println("joinedAt: " + participant.getJoinedAt());
+            System.out.println("audioEnabled: " + participant.isAudioEnabled());
+            System.out.println("videoEnabled: " + participant.isVideoEnabled());
+
+        } catch (Exception e) {
+            System.out.println("❌ 참가자 등록 실패!");
+            System.out.println("에러 타입: " + e.getClass().getSimpleName());
+            System.out.println("에러 메시지: " + e.getMessage());
+            if (e.getCause() != null) {
+                System.out.println("원인: " + e.getCause().getMessage());
+            }
+            e.printStackTrace();
+
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
# Summary
참가자 등록 시 발생하는 DB 제약조건 오류들을 수정했습니다.

# Changes
fix: Participant 엔티티 joinedAt null 에러 해결
fix: ParticipantRepository 존재하지 않는 필드 참조 오류 수정
fix: participant_id AUTO_INCREMENT 설정 누락 문제 해결
test: 참가자 등록 기능 테스트 코드 추가

# Details
- @PrePersist 어노테이션으로 joinedAt 필드 자동 설정하여 "Column 'joined_at' cannot be null" 에러 해결
- ParticipantRepository 쿼리에서 존재하지 않는 isMuted 필드를 audioEnabled = false로 변경
- MySQL 테이블 participant_id 컬럼에 AUTO_INCREMENT 누락으로 인한 "Field 'participant_id' doesn't have a default value" 에러 발견
- 로컬 환경에서 참가자 등록 기능 검증을 위한 단위 테스트 및 통합 테스트 추가
- Spring Data JPA Auditing 백업 로직으로 데이터 무결성 보장