### PR TITLE
Fix: 참가자 중복 입장 시 예외 대신 기존 정보 반환하도록 수정

### DIFF
--- a/src/main/java/org/oreo/smore/domain/participant/ParticipantService.java
+++ b/src/main/java/org/oreo/smore/domain/participant/ParticipantService.java
@@ -27,7 +27,12 @@ public class ParticipantService {
         StudyRoom studyRoom = validateStudyRoomExists(roomId);
 
         // 이미 참가중인지 확인
-        validateNotAlreadyInRoom(roomId, userId);
+        Participant existingParticipant = checkExistingParticipant(roomId, userId);
+        if (existingParticipant != null) {
+            log.info("✅ 기존 참가자 정보 반환 - 방ID: {}, 사용자ID: {}, 참가자ID: {}",
+                    roomId, userId, existingParticipant.getParticipantId());
+            return existingParticipant;
+        }
 
         // 방 최대 인원 확인
         validateRoomCapacity(studyRoom);
@@ -86,6 +91,24 @@ public class ParticipantService {
                     String.format("방이 가득함 (%d/%d)", currentCount, studyRoom.getMaxParticipants()));
         }
 
+    }
+
+    private Participant checkExistingParticipant(Long roomId, Long userId) {
+        List<Participant> activeParticipants = getActiveParticipants(roomId);
+
+        Participant existing = activeParticipants.stream()
+                .filter(p -> p.getUserId().equals(userId))
+                .findFirst()
+                .orElse(null);
+
+        if (existing != null) {
+            log.info("기존 활성 참가자 발견 - 방ID: {}, 사용자ID: {}, 참가자ID: {}",
+                    roomId, userId, existing.getParticipantId());
+        } else {
+            log.debug("신규 참가자 - 방ID: {}, 사용자ID: {}", roomId, userId);
+        }
+
+        return existing;
     }
 
     // 이미 참가중인지 검증


### PR DESCRIPTION
# Summary
참가자 중복 입장 시 발생하던 400 에러를 해결하고 사용자 경험을 개선했습니다.

# Changes
fix: ParticipantService 중복 참가 예외 처리 로직 개선
refactor: validateNotAlreadyInRoom 메서드 제거
feat: checkExistingParticipant 메서드 추가
improve: 중복 입장 시 기존 참가자 정보 반환 로직 구현

# Details
- "이미 참가중" 예외를 던지는 validateNotAlreadyInRoom 메서드 제거
- 기존 참가자 존재 시 예외 대신 해당 정보를 반환하는 checkExistingParticipant 메서드 추가
- joinRoom에서 중복 참가 시도 시 기존 참가자 정보를 반환하여 정상적인 토큰 발급 가능
- 네트워크 끊김 등으로 인한 재입장 시나리오에서 사용자 경험 크게 향상
- AlreadyJoinedException 발생 없이 원활한 방 입장 처리