### PR TITLE
fix: 인증 실패시 오류 코드 변경

### DIFF
--- a/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomController.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomController.java
@@ -35,7 +35,7 @@ public class StudyRoomController {
             }
         } catch (Exception e) {
             log.error("Authentication validation failed: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         log.info("스터디룸 생성 API 호출 - 사용자ID: {}, 제목: [{}]", userId, request.getTitle());
 

--- a/src/main/java/org/oreo/smore/domain/video/controller/VideoCallController.java
+++ b/src/main/java/org/oreo/smore/domain/video/controller/VideoCallController.java
@@ -48,7 +48,7 @@ public class VideoCallController {
             }
         } catch (Exception e) {
             log.error("Authentication validation failed: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         // User 테이블에서 nickname 가져오기
@@ -113,7 +113,7 @@ public class VideoCallController {
             }
         } catch (Exception e) {
             log.error("Authentication validation failed in rejoin: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         String userNickname = userIdentityService.generateIdentityForUser(userId);
@@ -157,7 +157,7 @@ public class VideoCallController {
             }
         } catch (Exception e) {
             log.error("인증 검증 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         log.info("개별 참가자 퇴장 요청 - 방ID: {}, 사용자ID: {}", roomId, userId);
@@ -225,7 +225,7 @@ public class VideoCallController {
             }
         } catch (Exception e) {
             log.error("인증 검증 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         log.warn("방 삭제 요청 - 방ID: {}, 방장ID: {}", roomId, ownerId);


### PR DESCRIPTION
## Summary
인증 검증 실패 시 반환하던 HTTP 401(Unauthorized) 상태 코드를 403(Forbidden)으로 변경했습니다.

## Changes
### 변경된 위치
**StudyRoomController**
스터디룸 생성(createStudyRoom) API의 예외 처리부
**VideoCallController**
참가 입장(joinRoom), 재입장(rejoinRoom), 퇴장(leaveRoom), 방 삭제(deleteStudyRoom) API의 예외 처리부

각 catch 블록에서
```java
return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
```
를
```java
return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
```
로 수정하여, 오류 처리를 적절한 403 상태를 반환하도록 했습니다.