### PR TITLE
Fix: String 응답도 ApiResponse로 감싸도록 로직 개선

### DIFF
--- a/src/main/java/org/oreo/smore/global/config/ApiResponseAdvice.java
+++ b/src/main/java/org/oreo/smore/global/config/ApiResponseAdvice.java
@@ -24,10 +24,14 @@ public class ApiResponseAdvice implements ResponseBodyAdvice<Object> {
 
         // 특정 경로는 제외 (필요에 따라 수정)
         String path = request.getURI().getPath();
-        if (body instanceof String ||
-                path.contains("/actuator") ||
+        if (path.contains("/actuator") ||
                 path.contains("/h2-console") ||
                 path.contains("/error")) {
+            return body;
+        }
+
+        if (selectedContentType != null &&
+                !selectedContentType.includes(MediaType.APPLICATION_JSON)) {
             return body;
         }
 

--- a/src/test/java/org/oreo/smore/global/config/ApiResponseAdviceTest.java
+++ b/src/test/java/org/oreo/smore/global/config/ApiResponseAdviceTest.java
@@ -1,0 +1,122 @@
+package org.oreo.smore.global.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.oreo.smore.global.common.ApiResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApiResponseAdviceTest {
+
+    @InjectMocks
+    private ApiResponseAdvice apiResponseAdvice;
+
+    @Mock
+    private MethodParameter methodParameter;
+
+    @Mock
+    private ServerHttpRequest request;
+
+    @Mock
+    private ServerHttpResponse response;
+
+    @Test
+    void ApiResponse로_이미_감싸진_경우_supports_false_반환() {
+        // Given
+        when(methodParameter.getParameterType()).thenReturn((Class) ApiResponse.class);
+
+        // When
+        boolean supports = apiResponseAdvice.supports(methodParameter, null);
+
+        // Then
+        assertThat(supports).isFalse();
+    }
+
+    @Test
+    void 일반_객체인_경우_supports_true_반환() {
+        // Given
+        when(methodParameter.getParameterType()).thenReturn((Class) String.class);
+
+        // When
+        boolean supports = apiResponseAdvice.supports(methodParameter, null);
+
+        // Then
+        assertThat(supports).isTrue();
+    }
+
+    @Test
+    void 일반_객체를_ApiResponse로_감싸서_반환() {
+        // Given
+        String testData = "test response";
+        when(request.getURI()).thenReturn(URI.create("/v1/test"));
+
+        // When
+        Object result = apiResponseAdvice.beforeBodyWrite(
+                testData, methodParameter, MediaType.APPLICATION_JSON,
+                null, request, response);
+
+        // Then
+        assertThat(result).isInstanceOf(ApiResponse.class);
+        ApiResponse<?> apiResponse = (ApiResponse<?>) result;
+        assertThat(apiResponse.getData()).isEqualTo(testData);
+    }
+
+    @Test
+    void String_응답은_그대로_반환() {
+        // Given
+        String stringResponse = "plain string";
+        when(request.getURI()).thenReturn(URI.create("/v1/test"));
+
+        // When
+        Object result = apiResponseAdvice.beforeBodyWrite(
+                stringResponse, methodParameter, MediaType.TEXT_PLAIN,
+                null, request, response);
+
+        // Then
+        assertThat(result).isEqualTo(stringResponse);
+        assertThat(result).isNotInstanceOf(ApiResponse.class);
+    }
+
+    @Test
+    void actuator_경로는_그대로_반환() {
+        // Given
+        String actuatorResponse = "actuator data";
+        when(request.getURI()).thenReturn(URI.create("/actuator/health"));
+
+        // When
+        Object result = apiResponseAdvice.beforeBodyWrite(
+                actuatorResponse, methodParameter, MediaType.APPLICATION_JSON,
+                null, request, response);
+
+        // Then
+        assertThat(result).isEqualTo(actuatorResponse);
+        assertThat(result).isNotInstanceOf(ApiResponse.class);
+    }
+
+    @Test
+    void null_데이터도_ApiResponse로_감싸서_반환() {
+        // Given
+        when(request.getURI()).thenReturn(URI.create("/v1/test"));
+
+        // When
+        Object result = apiResponseAdvice.beforeBodyWrite(
+                null, methodParameter, MediaType.APPLICATION_JSON,
+                null, request, response);
+
+        // Then
+        assertThat(result).isInstanceOf(ApiResponse.class);
+        ApiResponse<?> apiResponse = (ApiResponse<?>) result;
+        assertThat(apiResponse.getData()).isNull();
+    }
+}


### PR DESCRIPTION
# Summary
String 응답도 다른 객체와 동일하게 ApiResponse로 감싸서 API 응답 구조를 완전히 통일했습니다.

# Changes
fix: ApiResponseAdvice String 예외 처리 제거
improve: 모든 JSON 응답 래핑 일관성 확보
test: String 응답 래핑 동작 검증 테스트 추가
enhance: API 응답 구조 완전 표준화

# Details
- beforeBodyWrite에서 `body instanceof String` 조건 제거
- 이제 String 응답도 `{"data": "string_value"}` 형태로 반환
- actuator, h2-console, error 경로만 예외 처리 유지
- MediaType이 JSON이 아닌 경우에만 원본 응답 반환
- 프론트엔드에서 모든 API 응답을 response.data.data로 일관된 접근 가능
- API 응답 구조의 완전한 표준화로 개발 일관성 향상