### PR TITLE
Hotfix: 반환 오류(Advice, StringConvertor 문제)

### DIFF
--- a/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomController.java
+++ b/src/main/java/org/oreo/smore/domain/studyroom/StudyRoomController.java
@@ -51,7 +51,7 @@ public class StudyRoomController {
             @RequestParam(name="search", required=false) String search,
             @RequestParam(name="category", required=false) String category,
             @RequestParam(name="sort", defaultValue="latest") String sort,
-            @RequestParam(name="hide-full-rooms", defaultValue="false") boolean hideFullRooms
+            @RequestParam(name="hideFullRooms", defaultValue="false") boolean hideFullRooms
     ) {
         CursorPage<StudyRoomInfoReadResponse> studyRoomDtoCursorPage = studyRoomService.listStudyRooms(page, limit, search, category, sort, hideFullRooms);
         return ResponseEntity.ok(studyRoomDtoCursorPage);

--- a/src/main/java/org/oreo/smore/global/config/ApiResponseAdvice.java
+++ b/src/main/java/org/oreo/smore/global/config/ApiResponseAdvice.java
@@ -2,44 +2,80 @@ package org.oreo.smore.global.config;
 
 import org.oreo.smore.global.common.ApiResponse;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @ControllerAdvice
 public class ApiResponseAdvice implements ResponseBodyAdvice<Object> {
 
     @Override
-    public boolean supports(MethodParameter returnType, Class converterType) {
-        // 이미 ApiResponse로 감싸져 있으면 제외
-        return !returnType.getParameterType().equals(ApiResponse.class);
+    public boolean supports(MethodParameter returnType,
+                            Class<? extends HttpMessageConverter<?>> converterType) {
+
+        Class<?> type = returnType.getParameterType();
+
+        // 이미 ApiResponse면 제외
+        if (ApiResponse.class.isAssignableFrom(type)) return false;
+
+        // String(CharSequence) 반환은 제외 (String 컨버터와 충돌 방지)
+        if (CharSequence.class.isAssignableFrom(type)) return false;
+
+        // 파일/리소스/스트리밍/바이너리는 제외
+        if (Resource.class.isAssignableFrom(type)) return false;
+        if (StreamingResponseBody.class.isAssignableFrom(type)) return false;
+        if (type.equals(byte[].class)) return false;
+
+        // 선택된 컨버터가 String이면 제외 (ResponseEntity<String> 등)
+        if (StringHttpMessageConverter.class.isAssignableFrom(converterType)) return false;
+
+        return true;
     }
 
     @Override
-    public Object beforeBodyWrite(Object body, MethodParameter returnType,
-                                  MediaType selectedContentType, Class selectedConverterType,
-                                  ServerHttpRequest request, ServerHttpResponse response) {
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
 
-        // 특정 경로는 제외 (필요에 따라 수정)
+        // 특정 경로는 제외
         String path = request.getURI().getPath();
-        if (path.contains("/actuator") ||
-                path.contains("/h2-console") ||
-                path.contains("/error")) {
+        if (path.contains("/actuator")
+                || path.contains("/h2-console")
+                || path.contains("/error")) {
             return body;
         }
 
-        if (selectedContentType != null &&
-                !selectedContentType.includes(MediaType.APPLICATION_JSON)) {
+        // 이미 ApiResponse면 그대로 통과
+        if (body instanceof ApiResponse) {
             return body;
         }
 
-        // ResponseEntity의 body가 null인 경우 처리
+        // String 컨버터가 선택된 경우 래핑 금지 (핵심)
+        if (StringHttpMessageConverter.class.isAssignableFrom(selectedConverterType)) {
+            return body;
+        }
+
+        // JSON이 아닌 경우(파일 다운로드 등) 손대지 않음
+        if (selectedContentType == null
+                || !selectedContentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
+            return body;
+        }
+
+        // body가 null이면 통일된 포맷으로 래핑
         if (body == null) {
             return ApiResponse.of(null);
         }
 
+        // 그 외 객체는 ApiResponse로 래핑
         return ApiResponse.of(body);
     }
 }


### PR DESCRIPTION
## Summary
ApiResponseAdvice가 String 응답까지 래핑하면서 StringHttpMessageConverter와 충돌해 발생하던 ClassCastException을 해소했습니다.

이제 JSON 응답만 표준 포맷(ApiResponse)으로 래핑하고, String/파일/스트리밍 응답은 그대로 통과합니다.

## Changes
supports 시그니처 제네릭 적용: Class<? extends HttpMessageConverter<?>>.

래핑 예외 추가:

이미 ApiResponse 타입

CharSequence(= String) 반환

Resource, StreamingResponseBody, byte[] 반환

**선택 컨버터가 StringHttpMessageConverter**인 경우

beforeBodyWrite 로직 정리:

/actuator, /h2-console, /error 경로 예외 처리

이미 ApiResponse면 그대로 반환

선택 컨버터가 String이면 래핑 금지

MediaType.APPLICATION_JSON과 호환될 때만 래핑 (isCompatibleWith 사용)

body == null이면 ApiResponse.of(null)로 통일

## Details
원인: 컨트롤러가 String 바디(예: ResponseEntity.ok("OK"))를 반환 → 스프링이 StringHttpMessageConverter를 선택 → ResponseBodyAdvice가 이를 ApiResponse 객체로 바꿔치기 → 컨버터가 String을 기대해 ClassCastException 발생.

효과: 문자열/파일/스트리밍 응답은 안전하게 래핑 제외, JSON 응답만 일관된 포맷 유지. 500 에러 제거.

권장: 가능하면 API는 **DTO/Map/ApiResponse**로 반환하거나, 상태만 필요하면 204 No Content 사용. 전역 예외처리는 **@RestControllerAdvice**로 운영.

검증 포인트:

String 반환 엔드포인트 호출 시 그대로 문자열 응답

JSON 엔드포인트는 ApiResponse 포맷

/actuator 등 관리용 엔드포인트 변경 없음.









ChatGPT에게 묻기
